### PR TITLE
feat: register MongoDB

### DIFF
--- a/foca/database/register_mongodb.py
+++ b/foca/database/register_mongodb.py
@@ -1,0 +1,53 @@
+import os
+
+import logging
+from typing import Dict
+
+from flask import Flask
+from flask_pymongo import PyMongo
+
+from foca.config.config_parser import get_conf
+
+# Get logger instance
+logger = logging.getLogger(__name__)
+
+
+def create_mongo_client(
+    app: Flask,
+    config: Dict,
+):
+    """Register MongoDB uri and credentials."""
+    if os.environ.get('MONGO_USERNAME') != '':
+        auth = '{username}:{password}@'.format(
+            username=os.environ.get('MONGO_USERNAME'),
+            password=os.environ.get('MONGO_PASSWORD'),
+        )
+    else:
+        auth = ''
+
+    app.config['MONGO_URI'] = 'mongodb://{auth}{host}:{port}/{dbname}'.format(
+        host=os.environ.get('MONGO_HOST', get_conf(
+            config, 'database', 'host')),
+        port=os.environ.get('MONGO_PORT', get_conf(
+            config, 'database', 'port')),
+        dbname=os.environ.get('MONGO_DBNAME', get_conf(
+            config, 'database', 'name')),
+        auth=auth
+    )
+
+    """Instantiate MongoDB client."""
+    mongo = PyMongo(app)
+    logger.info(
+        (
+            "Registered database '{name}' at URI '{uri}':'{port}' with Flask "
+            'application.'
+        ).format(
+            name=os.environ.get('MONGO_DBNAME', get_conf(
+                config, 'database', 'name')),
+            uri=os.environ.get('MONGO_HOST', get_conf(
+                config, 'database', 'host')),
+            port=os.environ.get('MONGO_PORT', get_conf(
+                config, 'database', 'port'))
+        )
+    )
+    return mongo

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ coveralls==1.11.1
 flake8==3.7.9
 Flask==1.1.1
 Flask-Cors==3.0.8
+Flask-PyMongo==2.3.0
 mongomock==3.19.0
 pylint==2.4.4
 pymongo==3.10.1

--- a/tests/config/test_config_parser.py
+++ b/tests/config/test_config_parser.py
@@ -12,13 +12,8 @@ CONFIG_PATH_MISSING = []
 CONFIG_PATH_INVALID = ["tests/config/samplex.yaml"]
 
 
-"""
-Test that update_from_yaml return a string object
-"""
-
-
 def test_update_from_yaml_should_returns_str(monkeypatch):
-
+    """Test that update_from_yaml return a string object"""
     instance = YAMLConfigParser()
     print(instance)
     config_path = CONFIG_PATH_OK
@@ -29,13 +24,9 @@ def test_update_from_yaml_should_returns_str(monkeypatch):
     assert isinstance(res, str)
 
 
-"""
-update_from_yaml should return FileNotFoundError
-when file path is incorrect
-"""
-
-
 def test_update_from_yaml_should_return_FileNotFoundError():
+    """update_from_yaml should return FileNotFoundError when file
+    path is incorrect"""
 
     with pytest.raises(FileNotFoundError):
         instance = YAMLConfigParser()
@@ -44,13 +35,8 @@ def test_update_from_yaml_should_return_FileNotFoundError():
         instance.update_from_yaml(config_path, config_var)
 
 
-"""
-get_conf should return correct key value on call
-"""
-
-
 def test_get_conf():
-
+    """get_conf should return correct key value on call"""
     myDict = {
         "config1": {
             "config3": "val3"
@@ -66,14 +52,10 @@ def test_get_conf():
     assert res2 == "val2"
 
 
-"""
-get_conf should raise KeyError when an illegal
-value is provided for 'args' and touchy is false
-"""
-
-
 def test_get_conf_type_key_error():
-
+    """get_conf should raise KeyError when an illegal
+    value is provided for 'args' and touchy is false.
+    """
     with pytest.raises(KeyError):
         myDict = {
             "config1": "val1",
@@ -83,34 +65,27 @@ def test_get_conf_type_key_error():
         get_conf_type(myDict, arg1, touchy=False)
 
 
-"""
-get_conf_type should return SystemError
-when touchy is false and any exception is raised
-"""
-
-
 def test_get_conf_type_system_error():
+    """get_conf_type should return SystemError
+    when touchy is false and any exception is raised
+    """
     myDict = {
         "config1": "val1",
         "config2": "val2"
-        }
+    }
     with pytest.raises(SystemExit):
         arg1 = "config3"
         get_conf_type(myDict, arg1)
 
 
-"""
-invert_types is false and
-val is not an instance of types
-then return System Error
-"""
-
-
 def test_invert_types_false_returns_system_exit():
+    """invert_types is false and val is not an instance of types
+    then return SystemExit.
+    """
     myDict = {
-            "config1": "val1",
-            "config2": "val2"
-            }
+        "config1": "val1",
+        "config2": "val2"
+    }
     with pytest.raises(SystemExit):
         get_conf_type(
             myDict, "config1",
@@ -119,14 +94,10 @@ def test_invert_types_false_returns_system_exit():
             touchy=True)
 
 
-"""
-invert_types is false and
-val is an instance of types
-then return System Error
-"""
-
-
 def test_invert_types_true_returns_system_exit():
+    """invert_types is false and val is an instance of types
+    then return System Error
+    """
     myDict = {
         "config1": {
             "config3": "val3",

--- a/tests/config/test_log_config.py
+++ b/tests/config/test_log_config.py
@@ -10,56 +10,45 @@ import os
 
 
 CONFIG_VAR_OK = os.path.abspath(
-        os.path.join(
-            os.path.dirname(
-                os.path.realpath(__file__)
-            ),
-            'log_config.yaml'
-        )
+    os.path.join(
+        os.path.dirname(
+            os.path.realpath(__file__)
+        ),
+        'log_config.yaml'
     )
+)
 
 CONFIG_PATH_INVALID = os.path.abspath(
-        os.path.join(
-            os.path.dirname(
-                os.path.realpath(__file__)
-            ),
-            'log_config1.yaml'
-        )
+    os.path.join(
+        os.path.dirname(
+            os.path.realpath(__file__)
+        ),
+        'log_config1.yaml'
     )
-
-"""
-dictConfig is called once if config_var is undefined
-"""
+)
 
 
 @patch('foca.config.log_config.dictConfig')
 def test_configure_logging_config_var_undefined(test_patch):
+    """dictConfig is called once if config_var is undefined"""
     configure_logging("")
     assert test_patch.called is True
 
 
-"""
-dictConfig is not called if config_path does not have any file
-"""
-
-
 @patch('foca.config.log_config.dictConfig')
 def test_configure_logging_config_var_not_defined__file_not_found(test_patch):
+    """dictConfig is not called if config_path does not have any file"""
     # Assuming it will raise FileNotFoundError
     YAMLConfigParser.update_from_yaml = MagicMock(
-                                                side_effect=FileNotFoundError
-                                                )
+        side_effect=FileNotFoundError
+    )
     configure_logging(default_path=str(CONFIG_PATH_INVALID))
     assert test_patch.called is False
 
 
-"""
-dictConfig is called once if config_var is defined
-"""
-
-
 @patch('foca.config.log_config.dictConfig')
 def test_configure_logging_config_var_defined(test_patch):
+    """dictConfig is called once if config_var is defined"""
     os.environ['TEST_LOG_CONFIG'] = CONFIG_VAR_OK
     YAMLConfigParser.update_from_yaml = MagicMock()
     configure_logging(config_var="TEST_LOG_CONFIG")

--- a/tests/database/test_register_mongodb.py
+++ b/tests/database/test_register_mongodb.py
@@ -1,31 +1,94 @@
 """Tests for register_mongodb.py"""
 
-from foca.database.register_mongodb import create_mongo_client
-
 from flask import Flask
 from flask_pymongo import PyMongo
+from pymongo import DESCENDING
+from pymongo.operations import IndexModel
 
-DB_CONFIG_OK = ["tests/database/mock_config.yaml"]
-MY_DICT = {
+from foca.database.register_mongodb import (
+    create_mongo_client,
+    register_mongodb,
+)
+
+MONGO_CONFIG = {
     "database": {
         "host": "mongodb",
         "port": "27017",
         "name": "mock_db"
     }
 }
+DB_NAME = "my_database"
+COLL_NO_INDEXES = {
+    "coll_1": [],
+    "coll_2": [],
+}
+INDEX_MODEL = IndexModel(
+    [('my_id', DESCENDING)],
+    unique=True,
+    sparse=True
+)
+COLL_WITH_INDEXES = {
+    "coll_index": [INDEX_MODEL],
+}
 
 
-def test_create_mongo_client(monkeypatch):
+def test_create_mongo_client():
+    """When MONGO_USERNAME environement variable is NOT defined"""
+    app = Flask(__name__)
+    res = create_mongo_client(app, MONGO_CONFIG)
+    assert isinstance(res, PyMongo)
+
+
+def test_create_mongo_client_auth(monkeypatch):
     """When MONGO_USERNAME environement variable IS defined"""
     monkeypatch.setenv("MONGO_USERNAME", "TestingUser")
     app = Flask(__name__)
-    res = create_mongo_client(app, MY_DICT)
+    res = create_mongo_client(app, MONGO_CONFIG)
     assert isinstance(res, PyMongo)
 
 
-def test_create_mongo_client_env(monkeypatch):
+def test_create_mongo_client_auth_empty(monkeypatch):
     """When MONGO_USERNAME environment variable IS defined BUT null"""
     monkeypatch.setenv("MONGO_USERNAME", "")
     app = Flask(__name__)
-    res = create_mongo_client(app, MY_DICT)
+    res = create_mongo_client(app, MONGO_CONFIG)
     assert isinstance(res, PyMongo)
+
+
+def test_register_mongodb_no_collections():
+    """Register MongoDB database without any collections"""
+    app = Flask(__name__)
+    app.config.update(MONGO_CONFIG)
+    res = register_mongodb(
+        app=app,
+        db=DB_NAME,
+    )
+    assert isinstance(res, Flask)
+
+
+def test_register_mongodb_collections_with_default_index():
+    """Register MongoDB with collections and default indexes"""
+    app = Flask(__name__)
+    app.config.update(MONGO_CONFIG)
+    res = register_mongodb(
+        app=app,
+        db=DB_NAME,
+        collections=COLL_NO_INDEXES,
+    )
+    assert isinstance(res, Flask)
+
+
+def test_register_mongodb_collections_with_custom_index(monkeypatch):
+    """Register MongoDB with collections and custom indexes"""
+    monkeypatch.setattr(
+        'pymongo.collection.Collection.create_indexes',
+        lambda *args: None,
+    )
+    app = Flask(__name__)
+    app.config.update(MONGO_CONFIG)
+    res = register_mongodb(
+        app=app,
+        db=DB_NAME,
+        collections=COLL_WITH_INDEXES,
+    )
+    assert isinstance(res, Flask)

--- a/tests/database/test_register_mongodb.py
+++ b/tests/database/test_register_mongodb.py
@@ -1,0 +1,31 @@
+"""Tests for register_mongodb.py"""
+
+from foca.database.register_mongodb import create_mongo_client
+
+from flask import Flask
+from flask_pymongo import PyMongo
+
+DB_CONFIG_OK = ["tests/database/mock_config.yaml"]
+MY_DICT = {
+    "database": {
+        "host": "mongodb",
+        "port": "27017",
+        "name": "mock_db"
+    }
+}
+
+
+def test_create_mongo_client(monkeypatch):
+    """When MONGO_USERNAME environement variable IS defined"""
+    monkeypatch.setenv("MONGO_USERNAME", "TestingUser")
+    app = Flask(__name__)
+    res = create_mongo_client(app, MY_DICT)
+    assert isinstance(res, PyMongo)
+
+
+def test_create_mongo_client_env(monkeypatch):
+    """When MONGO_USERNAME environment variable IS defined BUT null"""
+    monkeypatch.setenv("MONGO_USERNAME", "")
+    app = Flask(__name__)
+    res = create_mongo_client(app, MY_DICT)
+    assert isinstance(res, PyMongo)


### PR DESCRIPTION
## Description

`register_mongodb.py` module in various service have two functions namely `create_mongo_client` and `register_mongodb`.

On some analysis it can be seen that, `create_mongo_client` function can be used for any service. But `register_mongodb` is specific to each service because it involves creating a database and collections which are specific to each service.

Closes #10 

Along with this change, there are some style changes in some previously written tests to follow [PEP-257](https://www.python.org/dev/peps/pep-0257/)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Style Changes

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage
