### PR TITLE
docs(api): add support for Google-style docstrings

### DIFF
--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -34,7 +34,8 @@ release = '0.2.0'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
## Description

Add Napoleon extension to Sphinx config to support parsing of Google- and Numpy-style docstrings.