### PR TITLE
feat(db): support for additional MongoDB features

### DIFF
--- a/foca/database/register_mongodb.py
+++ b/foca/database/register_mongodb.py
@@ -1,81 +1,84 @@
 """Register MongoDB with a Flask app."""
 
+import logging
 import os
 
-import logging
-
-from connexion import App
+from flask import Flask
 from flask_pymongo import PyMongo
-from foca.models.config import DBConfig
+from foca.models.config import MongoConfig
 
 # Get logger instance
 logger = logging.getLogger(__name__)
 
 
-def register_mongodb(app: App) -> App:
+def register_mongodb(
+    app: Flask,
+    conf: MongoConfig,
+    ) -> MongoConfig:
     """
     Instantiates a MongoDB database, initializes collections and adds the
-    database and collections to a Connexion app.
+    database and collections to a Flask app.
 
     Args:
-        app: Connexion app.
+        app: Flask application object.
+        conf: MongoDB configuration object.
 
     Returns:
         Flask application with updated config: `config['database']['database']`
             contains the database object; `config['database']['collections']`
             contains a dictionary of collection objects.
     """
-    conf = app.config['FOCA'].db
+    # Iterate over databases
+    if conf.dbs is not None:
+        for db_name, db_conf in conf.dbs.items():
 
-    # Instantiate PyMongo client
-    mongo = create_mongo_client(
-        app=app,
-        conf=conf,
-    )
+            # Instantiate PyMongo client
+            mongo = create_mongo_client(
+                app=app,
+                host=conf.host,
+                port=conf.port,
+                db=db_name,
+            )
 
-    # Add database
-    db = mongo.db[conf.name]
+            # Add database
+            db_conf.client = mongo.db
 
-    # Add database collections
-    registered_collections = {}
-    if conf.collections is not None:
-        for name, index_models in conf.collections.items():
-            registered_collections[name] = mongo.db[name]
-            if index_models.key is not None:
-                registered_collections[name].create_indexes(index_models.key,
-                                                            index_models
-                                                            .dict().pop("key"))
-            logger.debug(f"Added database collection '{name}'.")
-    else:
-        registered_collections = None
+            # Add collections
+            if db_conf.collections is not None:
+                for coll_name, coll_conf in db_conf.collections.items():
 
-    # Add database and collections to app config
-    conf.database = db
-    if registered_collections is not None:
-        for coll_name, reg_coll in registered_collections.items():
-            conf.collections[coll_name].connection = reg_coll
+                    coll_conf.client = mongo.db[coll_name]
+                    logger.info(
+                        f"Added database collection '{coll_name}'."
+                    )
 
-    app.config["FOCA"].db = conf
+                    # Add indices
+                    if coll_conf.indexes is not None:
+                        for index in coll_conf.indexes:
+                            if index.keys is not None:
+                                coll_conf.client.create_index(**index.dict())
 
-    return app
+    return conf
 
 
 def create_mongo_client(
-        app: App,
-        conf: DBConfig,
+        app: Flask,
+        host: str = 'mongodb',
+        port: int = 27017,
+        db: str = 'database',
 ) -> PyMongo:
     """Register MongoDB database with Flask app.
 
     Optionally, basic authorization can be set by environment variables.
 
     Args:
-        app: Flask application.
-        conf: An instance of the DBConfig class, with at least the attributes
-        `host`, `port` and database `name`. For further details, see
-        :py:class:`foca.models.config.DBConfig()`
+        app: Flask application object.
+        host: Host at which the MongoDB database is exposed.
+        port: Port at which the MongoDB database is exposed.
+        db: Name of the database to be accessed/created.
 
     Returns:
-        MongoDB client.
+        Client for the MongoDB database specified by `host`, `port` and `db`.
     """
     if os.environ.get('MONGO_USERNAME') != '':
         auth = '{username}:{password}@'.format(
@@ -85,22 +88,22 @@ def create_mongo_client(
     else:
         auth = ''
 
-    app.config['MONGO_URI'] = 'mongodb://{auth}{host}:{port}/{dbname}'.format(
-        host=os.environ.get('MONGO_HOST', conf.host),
-        port=os.environ.get('MONGO_PORT', conf.port),
-        dbname=os.environ.get('MONGO_DBNAME', conf.name),
+    app.config['MONGO_URI'] = 'mongodb://{auth}{host}:{port}/{db}'.format(
+        host=os.environ.get('MONGO_HOST', host),
+        port=os.environ.get('MONGO_PORT', port),
+        db=os.environ.get('MONGO_DBNAME', db),
         auth=auth
     )
 
     mongo = PyMongo(app)
     logger.info(
         (
-            "Registered database '{name}' at URI '{uri}':'{port}' with Flask "
+            "Registered database '{db}' at URI '{host}':'{port}' with Flask "
             'application.'
         ).format(
-            name=os.environ.get('MONGO_DBNAME', conf.name),
-            uri=os.environ.get('MONGO_HOST', conf.host),
-            port=os.environ.get('MONGO_PORT', conf.port)
+            db=os.environ.get('MONGO_DBNAME', db),
+            host=os.environ.get('MONGO_HOST', host),
+            port=os.environ.get('MONGO_PORT', port)
         )
     )
     return mongo

--- a/foca/database/register_mongodb.py
+++ b/foca/database/register_mongodb.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def register_mongodb(
     app: Flask,
     conf: MongoConfig,
-    ) -> MongoConfig:
+) -> MongoConfig:
     """
     Instantiates a MongoDB database, initializes collections and adds the
     database and collections to a Flask app.

--- a/foca/database/register_mongodb.py
+++ b/foca/database/register_mongodb.py
@@ -6,8 +6,7 @@ import logging
 
 from connexion import App
 from flask_pymongo import PyMongo
-from typing import Mapping
-
+from foca.models.config import DBConfig
 
 # Get logger instance
 logger = logging.getLogger(__name__)
@@ -26,39 +25,44 @@ def register_mongodb(app: App) -> App:
             contains the database object; `config['database']['collections']`
             contains a dictionary of collection objects.
     """
-    config = app.config
+    conf = app.config['FOCA'].db
 
     # Instantiate PyMongo client
     mongo = create_mongo_client(
         app=app,
-        config=config,
+        conf=conf,
     )
 
     # Add database
-    # db = mongo.db[config['FOCA'].db.name]
+    db = mongo.db[conf.name]
 
     # Add database collections
     registered_collections = {}
-    if config['FOCA'].db.collections is not None:
-        for name, index_models in config['FOCA'].db.collections.items():
+    if conf.collections is not None:
+        for name, index_models in conf.collections.items():
             registered_collections[name] = mongo.db[name]
-            if index_models:
-                registered_collections[name].create_indexes(index_models)
+            if index_models.key is not None:
+                registered_collections[name].create_indexes(index_models.key,
+                                                            index_models
+                                                            .dict().pop("key"))
             logger.debug(f"Added database collection '{name}'.")
     else:
         registered_collections = None
 
     # Add database and collections to app config
-    # config['FOCA'].db.database = db
-    config['FOCA'].db.collections = registered_collections
-    app.config = config
+    conf.database = db
+    if registered_collections is not None:
+        for coll_name, reg_coll in registered_collections.items():
+            conf.collections[coll_name].connection = reg_coll
+
+    app.config["FOCA"].db = conf
 
     return app
 
 
 def create_mongo_client(
-    app: App,
-    config: Mapping,
+        app: App,
+        conf: DBConfig,
 ) -> PyMongo:
     """Register MongoDB database with Flask app.
 
@@ -66,9 +70,9 @@ def create_mongo_client(
 
     Args:
         app: Flask application.
-        config: Mapping of configuration parameters with a key `database` and
-            a nested mapping of database configuration parameters, with at
-            least the keys `host`, `port` and database `name`.
+        conf: An instance of the DBConfig class, with at least the attributes
+        `host`, `port` and database `name`. For further details, see
+        :py:class:`foca.models.config.DBConfig()`
 
     Returns:
         MongoDB client.
@@ -82,9 +86,9 @@ def create_mongo_client(
         auth = ''
 
     app.config['MONGO_URI'] = 'mongodb://{auth}{host}:{port}/{dbname}'.format(
-        host=os.environ.get('MONGO_HOST', config['FOCA'].db.host),
-        port=os.environ.get('MONGO_PORT', config['FOCA'].db.port),
-        dbname=os.environ.get('MONGO_DBNAME', config['FOCA'].db.name),
+        host=os.environ.get('MONGO_HOST', conf.host),
+        port=os.environ.get('MONGO_PORT', conf.port),
+        dbname=os.environ.get('MONGO_DBNAME', conf.name),
         auth=auth
     )
 
@@ -94,9 +98,9 @@ def create_mongo_client(
             "Registered database '{name}' at URI '{uri}':'{port}' with Flask "
             'application.'
         ).format(
-            name=os.environ.get('MONGO_DBNAME', config['FOCA'].db.name),
-            uri=os.environ.get('MONGO_HOST', config['FOCA'].db.host),
-            port=os.environ.get('MONGO_PORT', config['FOCA'].db.port)
+            name=os.environ.get('MONGO_DBNAME', conf.name),
+            uri=os.environ.get('MONGO_HOST', conf.host),
+            port=os.environ.get('MONGO_PORT', conf.port)
         )
     )
     return mongo

--- a/foca/models/config.py
+++ b/foca/models/config.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 import os
-from typing import (Dict, List, Optional)
+from typing import (Dict, List, Optional, Mapping, Any,)
 
 from pydantic import (BaseModel, Field, validator)  # pylint: disable=E0611
 
@@ -358,6 +358,50 @@ class SecurityConfig(FOCABaseConfig):
     auth: AuthConfig = AuthConfig()
 
 
+class CollectionConfig(FOCABaseConfig):
+    """Model for configuring collections in a MongoDB instance attached to a
+    Flask or Connexion app.
+
+    Args:
+        name: custom name to use for this index - if none is given,
+            a name will be generated.
+        unique: if True creates a uniqueness constraint on the index.
+        background: if True this index should be created in the background.
+        sparse: if True, omit from the index any documents that lack the
+            indexed field.
+        expireAfterSeconds: Used to create an expiring (TTL) collection.
+            MongoDB will automatically delete documents from this collection
+            after <int> seconds. The indexed field must be a UTC datetime or
+            the data will not expire.
+        partialFilterExpression: A document that specifies a filter for a
+            partial index. Requires server version >= 3.2.
+
+    Attributes:
+        name: custom name to use for this index - if none is given,
+            a name will be generated.
+        unique: if True creates a uniqueness constraint on the index.
+        background: if True this index should be created in the background.
+        sparse: if True, omit from the index any documents that lack the
+            indexed field.
+        expireAfterSeconds: Used to create an expiring (TTL) collection.
+            MongoDB will automatically delete documents from this collection
+            after <int> seconds. The indexed field must be a UTC datetime or
+            the data will not expire.
+        partialFilterExpression: A document that specifies a filter for a
+            partial index. Requires server version >= 3.2.
+
+    Raises:
+        pydantic.ValidationError: The class was instantianted with an illegal
+            data type.
+    """
+    name: str = None
+    unique: bool
+    background: bool
+    sparse: bool
+    expireAfterSeconds: int
+    partialFilterExpression: Mapping[Any, Any]
+
+
 class DBConfig(FOCABaseConfig):
     """Model for configuring a MongoDB instance attached to a Flask or
     Connexion app.
@@ -366,11 +410,15 @@ class DBConfig(FOCABaseConfig):
         host: Host at which the database is exposed.
         port: Port at which the database is exposed.
         name: Database name.
+        collections: a :py:class: `foca.models.config.CollectionConfig()`
+            object
 
     Attributes:
         host: Host at which the database is exposed.
         port: Port at which the database is exposed.
         name: Database name.
+        collections: a :py:class: `foca.models.config.CollectionConfig()`
+            object
 
     Raises:
         pydantic.ValidationError: The class was instantianted with an illegal
@@ -387,6 +435,7 @@ class DBConfig(FOCABaseConfig):
     host: str = "mongodb"
     port: int = 27017
     name: str = "database"
+    collections: Dict[str, CollectionConfig] = None
 
 
 class JobsConfig(FOCABaseConfig):
@@ -413,7 +462,7 @@ class JobsConfig(FOCABaseConfig):
         >>> JobsConfig(
         ...     host="rabbitmq",
         ...     port=5672,
-        ...     backend='rpc://,
+        ...     backend='rpc://,'
         ...     include=[],
         ... )
         JobsConfig(host="rabbitmq",port=5672,backend='rpc://,include=[])

--- a/foca/models/config.py
+++ b/foca/models/config.py
@@ -395,8 +395,6 @@ class IndexConfig(FOCABaseConfig):
         background: Whether the index shall be created in the background.
         sparse: Whether documents that lack the indexed field shall be omitted
             from the index.
-        key: Key denoting a field to be indexed.
-        direction: Sort order of field. 
 
     Attributes:
         keys: A list of key-direction tuples indicating the field to be indexed

--- a/foca/models/config.py
+++ b/foca/models/config.py
@@ -2,9 +2,10 @@
 
 from enum import Enum
 import os
-from typing import (Dict, List, Optional, Mapping, Any, Union, Tuple, )
+from typing import (Dict, List, Optional, Tuple)
 
 from pydantic import (BaseModel, Field, validator)  # pylint: disable=E0611
+import pymongo
 
 
 def validate_log_level_choices(level: int) -> int:
@@ -37,6 +38,17 @@ class ValidationChecksEnum(Enum):
     pass."""
     all = "all"
     any = "any"
+
+
+class PymongoDirectionEnum(Enum):
+    """Supported directions for Pymongo indexes."""
+    ASCENDING = 1
+    DESCENDING = -1
+    GEO2D = "2d"
+    GEOHAYSTACK = "geoHaystack"
+    GEOSPHERE = "2dsphere"
+    HASHED = "hashed"
+    TEXT = "text"
 
 
 class FOCABaseConfig(BaseModel):
@@ -95,8 +107,8 @@ class ServerConfig(FOCABaseConfig):
         ...     testing=False,
         ...     use_reloader=True,
         ... )
-        ServerConfig(host="0.0.0.0",port=8080,debug=True,environment="developm\
-ent",testing=False,use_reloader=True)
+        ServerConfig(host='0.0.0.0', port=8080, debug=True, environment='devel\
+opment', testing=False, use_reloader=True)
     """
     host: str = "0.0.0.0"
     port: int = 8080
@@ -152,8 +164,8 @@ class SpecConfig(FOCABaseConfig):
 
     Example:
         >>> SpecConfig(
-        ...     path="/path/to/my/specs.yaml",
-        ...     path_out="/path/to/modified/specs.yaml",
+        ...     path="/path/to/specs.yaml",
+        ...     path_out="/path/to/specs.modified.yaml",
         ...     append=[
         ...         {
         ...             "security": {
@@ -173,10 +185,11 @@ class SpecConfig(FOCABaseConfig):
         ...         "x-some-other-custom-field": "some_value",
         ...     },
         ... )
-        SpecConfig(path='/path/to/my/specs.yaml', path_out='/path/to/modified/\
-specs.yaml', append=<list_iterator object at 0x7f12f0f56f10>, add_operation_fi\
-elds={'x-swagger-router-controller': 'controllers.my_specs', 'x-some-other-cus\
-tom-field': 'some_value'})
+        SpecConfig(path='/path/to/specs.yaml', path_out='/path/to/specs.modifi\
+ed.yaml', append=[{'security': {'jwt': {'type': 'apiKey', 'name': 'Authorizati\
+on', 'in': 'header'}}}, {'my_other_root_field': 'some_value'}], add_operation_\
+fields={'x-swagger-router-controller': 'controllers.my_specs', 'x-some-other-c\
+ustom-field': 'some_value'}, connexion=None)
     """
     path: str
     path_out: Optional[str] = None
@@ -214,10 +227,12 @@ class APIConfig(FOCABaseConfig):
             data type.
 
     Example:
-        >>> SpecConfig(
-        ...     spec=[SpecConfig],
+        >>> APIConfig(
+        ...     specs=[SpecConfig(path='/path/to/specs.yaml')],
         ... )
-        APIConfig(specs=[SpecConfig])
+        APIConfig(specs=[SpecConfig(path='/path/to/specs.yaml', path_out='/pat\
+h/to/specs.modified.yaml', append=None, add_operation_fields=None, connexion=N\
+one)])
     """
     specs: List[SpecConfig] = []
 
@@ -313,12 +328,13 @@ class AuthConfig(FOCABaseConfig):
         ...     validation_methods=["userinfo", "public_key"],
         ...     validation_checks="all",
         ... )
-        AuthConfig(required=False,add_key_to_claims=True,allow_expired=False,a\
-udience=None,claim_identity="sub",claim_issuer="iss",claim_key_id="kid",header\
-_name="Authorization",token_prefix="Bearer",algorithms=["RS256"],validation_me\
-thods=["userinfo", "public_key"],validation_checks="all")
+        AuthConfig(required=False, add_key_to_claims=True, allow_expired=False\
+, audience=None, claim_identity='sub', claim_issuer='iss', claim_key_id='kid',\
+ header_name='Authorization', token_prefix='Bearer', algorithms=['RS256'], val\
+idation_methods=[<ValidationMethodsEnum.userinfo: 'userinfo'>, <ValidationMeth\
+odsEnum.public_key: 'public_key'>], validation_checks=<ValidationChecksEnum.al\
+l: 'all'>)
     """
-
     required: bool = False
     add_key_to_claims: bool = True
     allow_expired: bool = False
@@ -351,52 +367,96 @@ class SecurityConfig(FOCABaseConfig):
 
     Example:
         >>> SecurityConfig(
-        ...     auth=AuthConfig(**kwargs),
+        ...     auth=AuthConfig(),
         ... )
-        SecurityConfig(auth=AuthConfig(**kwargs))
+        SecurityConfig(auth=AuthConfig(required=False, add_key_to_claims=True,\
+ allow_expired=False, audience=None, claim_identity='sub', claim_issuer='iss',\
+ claim_key_id='kid', header_name='Authorization', token_prefix='Bearer', algor\
+ithms=['RS256'], validation_methods=[<ValidationMethodsEnum.userinfo: 'userinf\
+o'>, <ValidationMethodsEnum.public_key: 'public_key'>], validation_checks=<Val\
+idationChecksEnum.all: 'all'>))
     """
     auth: AuthConfig = AuthConfig()
 
 
-class CollectionConfig(FOCABaseConfig):
-    """Model for configuring collections in a MongoDB instance attached to a
-    Flask or Connexion app.
+class IndexConfig(FOCABaseConfig):
+    """Model for configuring indexes for a MongoDB collection.
 
     Args:
-        key: Either a single key or a list of (key, direction) pairs. The
-            key(s) must be an instance of str, and the direction(s) must be one
-            of (ASCENDING, DESCENDING, GEO2D, GEOHAYSTACK, GEOSPHERE, HASHED,
-            TEXT).
-        name: custom name to use for this index - if none is given,
-            a name will be generated.
-        unique: if True creates a uniqueness constraint on the index.
-        background: if True this index should be created in the background.
-        sparse: if True, omit from the index any documents that lack the
-            indexed field.
-        expireAfterSeconds: Used to create an expiring (TTL) collection.
-            MongoDB will automatically delete documents from this collection
-            after <int> seconds. The indexed field must be a UTC datetime or
-            the data will not expire.
-        partialFilterExpression: A document that specifies a filter for a
-            partial index. Requires server version >= 3.2.
+        keys: A list of key-direction tuples indicating the field to be indexed
+            and the sort order of that index. The sort order must be a valid
+            MongoDB index specifier, one of `pymongo.ASCENDING`,
+            `pymongo.DESCENDING`, `pymongo.GEO2D` etc. or their corresponding
+            values `1`, `-1`, `'2d'`, respectively; cf.:
+            https://api.mongodb.com/python/current/api/pymongo/collection.html
+        name: Custom name to use for the index. If `None` is provided, a name
+            will be generated.
+        unique: Whether a uniqueness constraint shall be created on the index.
+        background: Whether the index shall be created in the background.
+        sparse: Whether documents that lack the indexed field shall be omitted
+            from the index.
+        key: Key denoting a field to be indexed.
+        direction: Sort order of field. 
 
     Attributes:
-        key: Either a single key or a list of (key, direction) pairs. The
-            key(s) must be an instance of str, and the direction(s) must be one
-            of (ASCENDING, DESCENDING, GEO2D, GEOHAYSTACK, GEOSPHERE, HASHED,
-            TEXT).
-        name: custom name to use for this index - if none is given,
-            a name will be generated.
-        unique: if True creates a uniqueness constraint on the index.
-        background: if True this index should be created in the background.
-        sparse: if True, omit from the index any documents that lack the
-            indexed field.
-        expireAfterSeconds: Used to create an expiring (TTL) collection.
-            MongoDB will automatically delete documents from this collection
-            after <int> seconds. The indexed field must be a UTC datetime or
-            the data will not expire.
-        partialFilterExpression: A document that specifies a filter for a
-            partial index. Requires server version >= 3.2.
+        keys: A list of key-direction tuples indicating the field to be indexed
+            and the sort order of that index. The sort order must be a valid
+            MongoDB index specifier, one of `pymongo.ASCENDING`,
+            `pymongo.DESCENDING`, `pymongo.GEO2D` etc. or their corresponding
+            values `1`, `-1`, `'2d'`, respectively; cf.:
+            https://api.mongodb.com/python/current/api/pymongo/collection.html
+        name: Custom name to use for the index. If `None` is provided, a name
+            will be generated.
+        unique: Whether a uniqueness constraint shall be created on the index.
+        background: Whether the index shall be created in the background.
+        sparse: Whether documents that lack the indexed field shall be omitted
+            from the index.
+
+    Raises:
+        pydantic.ValidationError: The class was instantianted with an illegal
+            data type.
+
+    Example:
+        >>> IndexConfig(
+        ...     keys=[('last_name', pymongo.DESCENDING)],
+        ...     unique=True,
+        ...     sparse=False,
+        ... )
+        IndexConfig(keys=[('last_name', -1)], name=None, unique=True, backgrou\
+nd=False, sparse=False)
+    """
+    keys: Optional[List[Tuple[str, PymongoDirectionEnum]]] = None
+    name: Optional[str] = None
+    unique: Optional[bool] = False
+    background: Optional[bool] = False
+    sparse: Optional[bool] = False
+
+    @validator('keys', always=True, allow_reuse=True)
+    def store_enum_value(cls, v):  # pylint: disable=E0213
+        """Store value of enumerator, rather than enumerator object."""
+        if not v:
+            return v
+        else:
+            new_v = []
+            for item in v:
+                tmp_list = list(item)
+                tmp_list[1] = tmp_list[1].value
+                new_v.append(tuple(tmp_list))
+            return new_v
+
+
+class CollectionConfig(FOCABaseConfig):
+    """Model for configuring a MongoDB collection.
+
+    Args:
+        indexes: An index configuration object.
+        client: Client connected to collection. Most likely populated through
+            the code, not during setup.
+
+    Attributes:
+        indexes: An index configuration object.
+        client: Client connected to collection. Most likely populated through
+            the code, not during setup.
 
     Raises:
         pydantic.ValidationError: The class was instantianted with an illegal
@@ -404,41 +464,29 @@ class CollectionConfig(FOCABaseConfig):
 
     Example:
         >>> CollectionConfig(
-        ...     key=[('my_id', DESCENDING)],
-        ...     unique=True,
-        ...     sparse=True,
+        ...     indexes=[IndexConfig(keys=[('last_name', 1)])],
         ... )
+        CollectionConfig(indexes=[IndexConfig(keys=[('last_name', 1)], name=No\
+ne, unique=False, background=False, sparse=False)], client=None)
     """
-    key: Union[str, List[Tuple[str, int]]] = None
-    name: str = None
-    unique: Optional[bool]
-    background: Optional[bool]
-    sparse: Optional[bool]
-    expireAfterSeconds: Optional[int]
-    partialFilterExpression: Optional[Mapping[Any, Any]]
-
-    class Config:
-        """Configuration for `pydantic` model class."""
-        extra = "allow"
+    indexes: Optional[List[IndexConfig]] = None
+    client: Optional[pymongo.collection.Collection] = None
 
 
 class DBConfig(FOCABaseConfig):
-    """Model for configuring a MongoDB instance attached to a Flask or
-    Connexion app.
+    """Model for configuring a MongoDB database.
 
     Args:
-        host: Host at which the database is exposed.
-        port: Port at which the database is exposed.
-        name: Database name.
-        collections: a :py:class: `foca.models.config.CollectionConfig()`
-            object
+        collections: Mapping of collection names (keys) and configuration
+            objects (values).
+        client: Client connected to database. Most likely populated through the
+            code, not during setup.
 
     Attributes:
-        host: Host at which the database is exposed.
-        port: Port at which the database is exposed.
-        name: Database name.
-        collections: a :py:class: `foca.models.config.CollectionConfig()`
-            object
+        collections: Mapping of collection names (keys) and configuration
+            objects (values).
+        client: Client connected to database. Most likely populated through the
+            code, not during setup.
 
     Raises:
         pydantic.ValidationError: The class was instantianted with an illegal
@@ -446,19 +494,50 @@ class DBConfig(FOCABaseConfig):
 
     Example:
         >>> DBConfig(
+        ...     collections={
+        ...         'my_collection': CollectionConfig(
+        ...             indexes=[IndexConfig(keys=[('last_name', 1)])],
+        ...         ),
+        ...     },
+        ... )
+        DBConfig(collections={'my_collection': CollectionConfig(indexes=[Index\
+Config(keys=[('last_name', 1)], name=None, unique=False, background=False, spa\
+rse=False)], client=None)}, client=None)
+    """
+    collections: Optional[Dict[str, CollectionConfig]] = None
+    client: Optional[pymongo.database.Database] = None
+
+
+class MongoConfig(FOCABaseConfig):
+    """Model for configuring a MongoDB instance attached to a Flask or
+    Connexion app.
+
+    Args:
+        host: Host at which the database is exposed.
+        port: Port at which the database is exposed.
+        dbs: Mapping of database names (keys) and configuration objects
+            (values).
+
+    Attributes:
+        host: Host at which the database is exposed.
+        port: Port at which the database is exposed.
+        dbs: Mapping of database names (keys) and configuration objects
+            (values).
+
+    Raises:
+        pydantic.ValidationError: The class was instantianted with an illegal
+            data type.
+
+    Example:
+        >>> MongoConfig(
         ...     host="mongodb",
         ...     port=27017,
-        ...     name="database",
         ... )
-        DBConfig(host="mongodb",port=27017,name="database")
+        MongoConfig(host='mongodb', port=27017, dbs=None)
     """
     host: str = "mongodb"
     port: int = 27017
-    name: str = "database"
-    collections: Optional[Dict[str, CollectionConfig]] = None
-
-    class Config:
-        extra = "allow"
+    dbs: Optional[Dict[str, DBConfig]] = None
 
 
 class JobsConfig(FOCABaseConfig):
@@ -485,10 +564,10 @@ class JobsConfig(FOCABaseConfig):
         >>> JobsConfig(
         ...     host="rabbitmq",
         ...     port=5672,
-        ...     backend='rpc://,'
+        ...     backend='rpc://',
         ...     include=[],
         ... )
-        JobsConfig(host="rabbitmq",port=5672,backend='rpc://,include=[])
+        JobsConfig(host='rabbitmq', port=5672, backend='rpc://', include=[])
     """
     host: str = "rabbitmq"
     port: int = 5672
@@ -515,12 +594,11 @@ class LogFormatterConfig(FOCABaseConfig):
 
     Example:
         >>> LogFormatterConfig(
-        ...     class_formatter=Field("logging.Formatter",alias="class"),
         ...     style="{",
         ...     format="[{asctime}: {levelname:<8}] {message} [{name}]",
         ... )
-        LogFormatterConfig(class_formatter=Field("logging.Formatter",alias="cl\
-ass"),style="{",format="[{asctime}: {levelname:<8}] {message} [{name}]")
+        LogFormatterConfig(class_formatter='logging.Formatter', style='{', for\
+mat='[{asctime}: {levelname:<8}] {message} [{name}]')
     """
     class_formatter: str = Field(
         "logging.Formatter",
@@ -551,13 +629,12 @@ class LogHandlerConfig(FOCABaseConfig):
 
     Example:
         >>> LogHandlerConfig(
-        ...     class_handler=Field("logging.StreamHandler",alias="class"),
         ...     level=20,
         ...     formatter="standard",
         ...     stream="ext://sys.stderr",
         ... )
-        LogHandlerConfig(class_handler=Field("logging.StreamHandler",alias="cl\
-ass"),level=20,formatter="standard",stream="ext://sys.stderr")
+        LogHandlerConfig(class_handler='logging.StreamHandler', level=20, form\
+atter='standard', stream='ext://sys.stderr')
     """
     class_handler: str = Field(
         "logging.StreamHandler",
@@ -589,10 +666,10 @@ class LogRootConfig(FOCABaseConfig):
 
     Example:
         >>> LogRootConfig(
-        ...     level=10,
+        ...     level=logging.INFO,
         ...     handlers=["console"],
         ... )
-        LogRootConfig(level=10,handlers=["console"])
+        LogRootConfig(level=20, handlers=['console'])
     """
     level: int = 10
     handlers: Optional[List[str]] = ["console"]
@@ -645,9 +722,12 @@ class LogConfig(FOCABaseConfig):
         ...     },
         ...     root=LogRootConfig()
         ... )
-        LogConfig(version=1,disable_existing_loggers=False,formatters={"standa\
-rd": LogFormatterConfig()},handlers={"console": LogHandlerConfig()},root=LogRo\
-otConfig())
+        LogConfig(version=1, disable_existing_loggers=False, formatters={'stan\
+dard': LogFormatterConfig(class_formatter='logging.Formatter', style='{', form\
+at='[{asctime}: {levelname:<8}] {message} [{name}]')}, handlers={'console': Lo\
+gHandlerConfig(class_handler='logging.StreamHandler', level=20, formatter='sta\
+ndard', stream='ext://sys.stderr')}, root=LogRootConfig(level=10, handlers=['c\
+onsole']))
     """
     version: int = 1
     disable_existing_loggers: bool = False
@@ -684,20 +764,25 @@ class Config(FOCABaseConfig):
             data type.
 
     Example:
-        >>> DBConfig(
-        ...     server=ServerConfig(**kwargs),
-        ...     api=APIConfig(**kwargs),
-        ...     security=SecurityConfig(**kwargs),
-        ...     db=DBConfig(**kwargs),
-        ...     jobs=JobsConfig(**kwargs),
-        ...     log=LogConfig(**kwargs),
-        ... )
-        DBConfig(host="mongodb",port=27017,name="database")
+        >>> Config()
+        Config(server=ServerConfig(host='0.0.0.0', port=8080, debug=True, envi\
+ronment='development', testing=False, use_reloader=True), api=APIConfig(specs=\
+[]), security=SecurityConfig(auth=AuthConfig(required=False, add_key_to_claims\
+=True, allow_expired=False, audience=None, claim_identity='sub', claim_issuer=\
+'iss', claim_key_id='kid', header_name='Authorization', token_prefix='Bearer',\
+ algorithms=['RS256'], validation_methods=[<ValidationMethodsEnum.userinfo: 'u\
+serinfo'>, <ValidationMethodsEnum.public_key: 'public_key'>], validation_check\
+s=<ValidationChecksEnum.all: 'all'>)), db=None, jobs=None, log=LogConfig(versi\
+on=1, disable_existing_loggers=False, formatters={'standard': LogFormatterConf\
+ig(class_formatter='logging.Formatter', style='{', format='[{asctime}: {leveln\
+ame:<8}] {message} [{name}]')}, handlers={'console': LogHandlerConfig(class_ha\
+ndler='logging.StreamHandler', level=20, formatter='standard', stream='ext://s\
+ys.stderr')}, root=LogRootConfig(level=10, handlers=['console'])))
     """
     server: ServerConfig = ServerConfig()
     api: APIConfig = APIConfig()
     security: SecurityConfig = SecurityConfig()
-    db: Optional[DBConfig] = None
+    db: Optional[MongoConfig] = None
     jobs: Optional[JobsConfig] = None
     log: LogConfig = LogConfig()
 

--- a/foca/models/config.py
+++ b/foca/models/config.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 import os
-from typing import (Dict, List, Optional, Mapping, Any,)
+from typing import (Dict, List, Optional, Mapping, Any, Union, Tuple, )
 
 from pydantic import (BaseModel, Field, validator)  # pylint: disable=E0611
 
@@ -363,6 +363,10 @@ class CollectionConfig(FOCABaseConfig):
     Flask or Connexion app.
 
     Args:
+        key: Either a single key or a list of (key, direction) pairs. The
+            key(s) must be an instance of str, and the direction(s) must be one
+            of (ASCENDING, DESCENDING, GEO2D, GEOHAYSTACK, GEOSPHERE, HASHED,
+            TEXT).
         name: custom name to use for this index - if none is given,
             a name will be generated.
         unique: if True creates a uniqueness constraint on the index.
@@ -377,6 +381,10 @@ class CollectionConfig(FOCABaseConfig):
             partial index. Requires server version >= 3.2.
 
     Attributes:
+        key: Either a single key or a list of (key, direction) pairs. The
+            key(s) must be an instance of str, and the direction(s) must be one
+            of (ASCENDING, DESCENDING, GEO2D, GEOHAYSTACK, GEOSPHERE, HASHED,
+            TEXT).
         name: custom name to use for this index - if none is given,
             a name will be generated.
         unique: if True creates a uniqueness constraint on the index.
@@ -393,13 +401,25 @@ class CollectionConfig(FOCABaseConfig):
     Raises:
         pydantic.ValidationError: The class was instantianted with an illegal
             data type.
+
+    Example:
+        >>> CollectionConfig(
+        ...     key=[('my_id', DESCENDING)],
+        ...     unique=True,
+        ...     sparse=True,
+        ... )
     """
+    key: Union[str, List[Tuple[str, int]]] = None
     name: str = None
-    unique: bool
-    background: bool
-    sparse: bool
-    expireAfterSeconds: int
-    partialFilterExpression: Mapping[Any, Any]
+    unique: Optional[bool]
+    background: Optional[bool]
+    sparse: Optional[bool]
+    expireAfterSeconds: Optional[int]
+    partialFilterExpression: Optional[Mapping[Any, Any]]
+
+    class Config:
+        """Configuration for `pydantic` model class."""
+        extra = "allow"
 
 
 class DBConfig(FOCABaseConfig):
@@ -435,7 +455,10 @@ class DBConfig(FOCABaseConfig):
     host: str = "mongodb"
     port: int = 27017
     name: str = "database"
-    collections: Dict[str, CollectionConfig] = None
+    collections: Optional[Dict[str, CollectionConfig]] = None
+
+    class Config:
+        extra = "allow"
 
 
 class JobsConfig(FOCABaseConfig):

--- a/tests/config/test_config_parser.py
+++ b/tests/config/test_config_parser.py
@@ -20,14 +20,13 @@ def test_config_parser_valid_config_file():
     """Test valid YAML parsing"""
     conf = ConfigParser(TEST_FILE)
     assert type(conf.config.dict()) == type(TEST_DICT)
-    assert type(conf.config) == type(TEST_CONFIG_INSTANCE)
+    assert isinstance(conf.config, type(TEST_CONFIG_INSTANCE))
 
 
 def test_config_parser_invalid_config_file():
     """Test valid YAML parsing"""
     with pytest.raises(ValidationError):
-        conf = ConfigParser(TEST_FILE_INVALID)
-        assert conf is not None
+        ConfigParser(TEST_FILE_INVALID)
 
 
 def test_config_parser_invalid_file_path():

--- a/tests/config/test_config_parser.py
+++ b/tests/config/test_config_parser.py
@@ -13,14 +13,14 @@ from foca.models.config import Config
 TEST_FILE = "tests/test_files/conf_valid.yaml"
 TEST_FILE_INVALID = "tests/test_files/conf_invalid_log_level.yaml"
 TEST_DICT = {}
-TEST_CONFIG_INSTACE = Config()
+TEST_CONFIG_INSTANCE = Config()
 
 
 def test_config_parser_valid_config_file():
     """Test valid YAML parsing"""
     conf = ConfigParser(TEST_FILE)
     assert type(conf.config.dict()) == type(TEST_DICT)
-    assert type(conf.config) == type(TEST_CONFIG_INSTACE)
+    assert type(conf.config) == type(TEST_CONFIG_INSTANCE)
 
 
 def test_config_parser_invalid_config_file():

--- a/tests/database/test_register_mongodb.py
+++ b/tests/database/test_register_mongodb.py
@@ -27,7 +27,7 @@ DB_DICT_DEF_COLL = {
         }
     }
 }
-DB_DICT_CUST_COLL= {
+DB_DICT_CUST_COLL = {
     'my_db': {
         'collections': {
             'my_collection': {

--- a/tests/database/test_register_mongodb.py
+++ b/tests/database/test_register_mongodb.py
@@ -3,77 +3,74 @@
 from flask import Flask
 from flask_pymongo import PyMongo
 from pymongo import DESCENDING
-from pymongo.operations import IndexModel
 
 from foca.database.register_mongodb import (
     create_mongo_client,
     register_mongodb,
 )
+from foca.factories.connexion_app import create_connexion_app
+from foca.models.config import Config, DBConfig, CollectionConfig
 
-MONGO_CONFIG = {
-    "database": {
-        "host": "mongodb",
-        "port": "27017",
-        "name": "mock_db"
-    }
-}
+CONFIG = Config(db=DBConfig(host="mongodb", port=27017, name="mock_db"))
+
 DB_NAME = "my_database"
 COLL_NO_INDEXES = {
-    "coll_1": [],
-    "coll_2": [],
+    "coll_1": CollectionConfig(),
+    "coll_2": CollectionConfig(),
 }
-INDEX_MODEL = IndexModel(
-    [('my_id', DESCENDING)],
-    unique=True,
-    sparse=True
-)
+
 COLL_WITH_INDEXES = {
-    "coll_index": [INDEX_MODEL],
+    "coll_index": CollectionConfig(key=[('my_id', DESCENDING)],
+                                   unique=True,
+                                   sparse=True)
 }
 
 
 def test_create_mongo_client():
     """When MONGO_USERNAME environement variable is NOT defined"""
-    app = Flask(__name__)
-    res = create_mongo_client(app, MONGO_CONFIG)
+    # app = Flask(__name__)
+    app = create_connexion_app(CONFIG)
+    res = create_mongo_client(app.app, CONFIG.db)
     assert isinstance(res, PyMongo)
 
 
 def test_create_mongo_client_auth(monkeypatch):
     """When MONGO_USERNAME environement variable IS defined"""
     monkeypatch.setenv("MONGO_USERNAME", "TestingUser")
-    app = Flask(__name__)
-    res = create_mongo_client(app, MONGO_CONFIG)
+    # app = Flask(__name__)
+    app = create_connexion_app(CONFIG)
+    res = create_mongo_client(app.app, CONFIG.db)
     assert isinstance(res, PyMongo)
 
 
 def test_create_mongo_client_auth_empty(monkeypatch):
     """When MONGO_USERNAME environment variable IS defined BUT null"""
     monkeypatch.setenv("MONGO_USERNAME", "")
-    app = Flask(__name__)
-    res = create_mongo_client(app, MONGO_CONFIG)
+    # app = Flask(__name__)
+    app = create_connexion_app(CONFIG)
+    res = create_mongo_client(app.app, CONFIG.db)
     assert isinstance(res, PyMongo)
 
 
 def test_register_mongodb_no_collections():
     """Register MongoDB database without any collections"""
-    app = Flask(__name__)
-    app.config.update(MONGO_CONFIG)
+    # app = Flask(__name__)
+    app = create_connexion_app(CONFIG)
+    temp_config = CONFIG.db.collections = COLL_NO_INDEXES
+    app.app.config.update(temp_config)
     res = register_mongodb(
-        app=app,
-        db=DB_NAME,
+        app=app.app
     )
     assert isinstance(res, Flask)
 
 
 def test_register_mongodb_collections_with_default_index():
     """Register MongoDB with collections and default indexes"""
-    app = Flask(__name__)
-    app.config.update(MONGO_CONFIG)
+    # app = Flask(__name__)
+    app = create_connexion_app(CONFIG)
+    app.app.config.update(CONFIG)
     res = register_mongodb(
-        app=app,
-        db=DB_NAME,
-        collections=COLL_NO_INDEXES,
+        app=app.app
     )
     assert isinstance(res, Flask)
 
@@ -84,11 +81,11 @@ def test_register_mongodb_collections_with_custom_index(monkeypatch):
         'pymongo.collection.Collection.create_indexes',
         lambda *args: None,
     )
-    app = Flask(__name__)
-    app.config.update(MONGO_CONFIG)
+    # app = Flask(__name__)
+    app = create_connexion_app(CONFIG)
+    temp_config = CONFIG.db.collections = COLL_WITH_INDEXES
+    app.app.config.update(temp_config)
     res = register_mongodb(
-        app=app,
-        db=DB_NAME,
-        collections=COLL_WITH_INDEXES,
+        app=app.app
     )
     assert isinstance(res, Flask)

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -1,0 +1,86 @@
+"""Tests for config.py."""
+
+from foca.models.config import (
+    Config,
+    CollectionConfig,
+    DBConfig,
+    IndexConfig,
+    MongoConfig,
+)
+
+INDEX_CONFIG = {
+    'keys': [('last_name', -1)],
+    'name': 'indexLastName',
+    'unique': True,
+    'background': False,
+    'sparse': False,
+}
+COLLECTION_CONFIG = {
+    'indexes': [INDEX_CONFIG],
+}
+DB_CONFIG = {
+    'collections': {
+        'wes-col': COLLECTION_CONFIG,
+    },
+}
+MONGO_CONFIG = {
+    'host': 'mongodb',
+    'port': 27017,
+    'dbs': {
+        'wes': DB_CONFIG,
+    },
+}
+
+
+def test_config_empty():
+    """Test basic creation of the main config model."""
+    res = Config()
+    assert isinstance(res, Config)
+
+
+def test_index_config_empty():
+    """Test basic creation of the IndexConfig model."""
+    res = IndexConfig()
+    assert isinstance(res, IndexConfig)
+
+
+def test_index_config_with_data():
+    """Test creation of the IndexConfig model with data."""
+    res = IndexConfig(**INDEX_CONFIG)
+    assert isinstance(res, IndexConfig)
+
+
+def test_collection_config_empty():
+    """Test basic creation of the CollectionConfig model."""
+    res = CollectionConfig()
+    assert isinstance(res, CollectionConfig)
+
+
+def test_collection_config_with_data():
+    """Test creation of the CollectionConfig model with data."""
+    res = CollectionConfig(**COLLECTION_CONFIG)
+    assert isinstance(res, CollectionConfig)
+
+
+def test_db_config_empty():
+    """Test basic creation of the DBConfig model."""
+    res = DBConfig()
+    assert isinstance(res, DBConfig)
+
+
+def test_db_config_with_data():
+    """Test creation of the DBConfig model with data."""
+    res = DBConfig(**DB_CONFIG)
+    assert isinstance(res, DBConfig)
+
+
+def test_mongo_config_empty():
+    """Test basic creation of the MongoConfig model."""
+    res = MongoConfig()
+    assert isinstance(res, MongoConfig)
+
+
+def test_mongo_config_with_data():
+    """Test creation of the MongoConfig model with data."""
+    res = MongoConfig(**MONGO_CONFIG)
+    assert isinstance(res, MongoConfig)

--- a/tests/test_files/conf_invalid_log_level.yaml
+++ b/tests/test_files/conf_invalid_log_level.yaml
@@ -33,9 +33,13 @@ security:
         validation_checks: all
 
 db:
-    host: mongodb
+    host: mongo
     port: 27017
-    name: cwl-wes-db
+    dbs:
+        my_db:
+            collections:
+                my-col-1:
+                    indexes: null
 
 jobs:
     host: rabbitmq

--- a/tests/test_files/conf_valid.yaml
+++ b/tests/test_files/conf_valid.yaml
@@ -33,9 +33,13 @@ security:
         validation_checks: all
 
 db:
-    host: mongodb
+    host: mongo
     port: 27017
-    name: cwl-wes-db
+    dbs:
+        my_db:
+            collections:
+                my-col-1:
+                    indexes: null
 
 jobs:
     host: rabbitmq

--- a/tests/test_files/openapi_2_petstore.modified.yaml
+++ b/tests/test_files/openapi_2_petstore.modified.yaml
@@ -103,4 +103,9 @@ produces:
 - application/json
 schemes:
 - http
+securityDefinitions:
+  jwt:
+    in: header
+    name: Authorization
+    type: apiKey
 swagger: '2.0'

--- a/tests/test_files/openapi_2_petstore.modified.yaml
+++ b/tests/test_files/openapi_2_petstore.modified.yaml
@@ -103,9 +103,4 @@ produces:
 - application/json
 schemes:
 - http
-securityDefinitions:
-  jwt:
-    in: header
-    name: Authorization
-    type: apiKey
 swagger: '2.0'


### PR DESCRIPTION
## Description

FOCA can be configured to:
- add multiple databases
- add multiple collections per database
- add rich indices for each collection

Moreover, the main database registration module was refactored to make use of class-based configuration.

Fixes #52