### PR TITLE
fix(api): fix resolution of relative spec paths

### DIFF
--- a/foca/api/register_openapi.py
+++ b/foca/api/register_openapi.py
@@ -2,6 +2,7 @@
 """
 
 import logging
+from pathlib import Path
 from typing import List
 
 from connexion import App
@@ -38,6 +39,8 @@ def register_openapi(
     """
     # Iterate over OpenAPI specs
     for spec in specs:
+        if not Path(spec.path).is_absolute():
+            spec.path = str(Path.cwd() / spec.path)
         spec_modified = False
         logger.warning(spec)
         spec_parsed = ConfigParser.parse_yaml(spec.path)

--- a/tests/api/test_register_openapi.py
+++ b/tests/api/test_register_openapi.py
@@ -12,7 +12,8 @@ from foca.api.register_openapi import register_openapi
 from foca.models.config import SpecConfig
 
 DIR = pathlib.Path(__file__).parent.parent / "test_files"
-PATH_SPECS_2_YAML = str(DIR / "openapi_2_petstore.yaml")
+#PATH_SPECS_2_YAML = str(DIR / "openapi_2_petstore.yaml")
+PATH_SPECS_2_YAML = "tests/test_files/openapi_2_petstore.yaml"
 PATH_SPECS_2_YAML_MODIFIED = str(DIR / "openapi_2_petstore.modified.yaml")
 PATH_SPECS_2_JSON = str(DIR / "openapi_2_petstore.yaml")
 PATH_SPECS_3_YAML = str(DIR / "openapi_3_petstore.yaml")
@@ -20,6 +21,7 @@ PATH_SPECS_3_YAML_MODIFIED = str(DIR / "openapi_3_petstore.modified.yaml")
 PATH_SPECS_INVALID_JSON = str(DIR / "invalid.json")
 PATH_SPECS_INVALID_OPENAPI = str(DIR / "invalid_openapi_2.yaml")
 PATH_SPECS_NOT_EXIST = str(DIR / "does/not/exist.yaml")
+PATH_SPECS_NOT_EXIST_REL = str("does_not_exist.yaml")
 OPERATION_FIELDS = {"x-swagger-router-controller": "controllers"}
 OPERATION_FIELDS_NOT_SERIALIZABLE = {
     "x-swagger-router-controller": InvalidSpecification
@@ -112,6 +114,16 @@ def test_register_openapi_spec_file_not_found():
     """
     app = App(__name__)
     spec_configs = [SpecConfig(path=PATH_SPECS_NOT_EXIST)]
+    with pytest.raises(OSError):
+        register_openapi(app=app, specs=spec_configs)
+
+
+def test_register_openapi_spec_file_not_found_rel_path():
+    """Registering OpenAPI specs fails because the spec file, indicated as a
+    relative path is not available.
+    """
+    app = App(__name__)
+    spec_configs = [SpecConfig(path=PATH_SPECS_NOT_EXIST_REL)]
     with pytest.raises(OSError):
         register_openapi(app=app, specs=spec_configs)
 

--- a/tests/api/test_register_openapi.py
+++ b/tests/api/test_register_openapi.py
@@ -12,8 +12,10 @@ from foca.api.register_openapi import register_openapi
 from foca.models.config import SpecConfig
 
 DIR = pathlib.Path(__file__).parent.parent / "test_files"
-#PATH_SPECS_2_YAML = str(DIR / "openapi_2_petstore.yaml")
-PATH_SPECS_2_YAML = "tests/test_files/openapi_2_petstore.yaml"
+PATH_SPECS_2_YAML = str(DIR / "openapi_2_petstore.yaml")
+PATH_SPECS_2_YAML_REL = str(
+    pathlib.Path("tests") / "test_files" / "openapi_2_petstore.yaml"
+)
 PATH_SPECS_2_YAML_MODIFIED = str(DIR / "openapi_2_petstore.modified.yaml")
 PATH_SPECS_2_JSON = str(DIR / "openapi_2_petstore.yaml")
 PATH_SPECS_3_YAML = str(DIR / "openapi_3_petstore.yaml")
@@ -27,7 +29,7 @@ OPERATION_FIELDS_NOT_SERIALIZABLE = {
     "x-swagger-router-controller": InvalidSpecification
 }
 SPEC_CONFIG = {
-    "path": PATH_SPECS_2_YAML,
+    "path": PATH_SPECS_2_YAML_REL,
     "path_out": PATH_SPECS_2_YAML_MODIFIED,
     "append": [
         {


### PR DESCRIPTION
## Description

Interpret relative OpenAPI spec paths in config file relative to the current working directory of the caller. Previously was relative to Python's current execution directory which is unstable and almost never what the user wants.