### PR TITLE
refactor(api): resolve relative path in spec model

### DIFF
--- a/foca/api/register_openapi.py
+++ b/foca/api/register_openapi.py
@@ -2,7 +2,6 @@
 """
 
 import logging
-from pathlib import Path
 from typing import List
 
 from connexion import App
@@ -39,8 +38,6 @@ def register_openapi(
     """
     # Iterate over OpenAPI specs
     for spec in specs:
-        if not Path(spec.path).is_absolute():
-            spec.path = str(Path.cwd() / spec.path)
         spec_modified = False
         logger.warning(spec)
         spec_parsed = ConfigParser.parse_yaml(spec.path)

--- a/tests/api/test_register_openapi.py
+++ b/tests/api/test_register_openapi.py
@@ -13,9 +13,6 @@ from foca.models.config import SpecConfig
 
 DIR = pathlib.Path(__file__).parent.parent / "test_files"
 PATH_SPECS_2_YAML = str(DIR / "openapi_2_petstore.yaml")
-PATH_SPECS_2_YAML_REL = str(
-    pathlib.Path("tests") / "test_files" / "openapi_2_petstore.yaml"
-)
 PATH_SPECS_2_YAML_MODIFIED = str(DIR / "openapi_2_petstore.modified.yaml")
 PATH_SPECS_2_JSON = str(DIR / "openapi_2_petstore.yaml")
 PATH_SPECS_3_YAML = str(DIR / "openapi_3_petstore.yaml")
@@ -23,13 +20,12 @@ PATH_SPECS_3_YAML_MODIFIED = str(DIR / "openapi_3_petstore.modified.yaml")
 PATH_SPECS_INVALID_JSON = str(DIR / "invalid.json")
 PATH_SPECS_INVALID_OPENAPI = str(DIR / "invalid_openapi_2.yaml")
 PATH_SPECS_NOT_EXIST = str(DIR / "does/not/exist.yaml")
-PATH_SPECS_NOT_EXIST_REL = str("does_not_exist.yaml")
 OPERATION_FIELDS = {"x-swagger-router-controller": "controllers"}
 OPERATION_FIELDS_NOT_SERIALIZABLE = {
     "x-swagger-router-controller": InvalidSpecification
 }
 SPEC_CONFIG = {
-    "path": PATH_SPECS_2_YAML_REL,
+    "path": PATH_SPECS_2_YAML,
     "path_out": PATH_SPECS_2_YAML_MODIFIED,
     "append": [
         {
@@ -116,16 +112,6 @@ def test_register_openapi_spec_file_not_found():
     """
     app = App(__name__)
     spec_configs = [SpecConfig(path=PATH_SPECS_NOT_EXIST)]
-    with pytest.raises(OSError):
-        register_openapi(app=app, specs=spec_configs)
-
-
-def test_register_openapi_spec_file_not_found_rel_path():
-    """Registering OpenAPI specs fails because the spec file, indicated as a
-    relative path is not available.
-    """
-    app = App(__name__)
-    spec_configs = [SpecConfig(path=PATH_SPECS_NOT_EXIST_REL)]
     with pytest.raises(OSError):
         register_openapi(app=app, specs=spec_configs)
 

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -1,11 +1,17 @@
 """Tests for config.py."""
 
+from pathlib import Path
+
+from pydantic import ValidationError
+import pytest
+
 from foca.models.config import (
     Config,
     CollectionConfig,
     DBConfig,
     IndexConfig,
     MongoConfig,
+    SpecConfig,
 )
 
 INDEX_CONFIG = {
@@ -29,6 +35,31 @@ MONGO_CONFIG = {
     'dbs': {
         'wes': DB_CONFIG,
     },
+}
+SPEC_CONFIG = {
+    'path': '/my/abs/path',
+    'path_out': '/my/abs/out/path',
+}
+SPEC_CONFIG_REL_IN = {
+    'path': 'path',
+    'path_out': '/my/abs/out/path',
+}
+SPEC_CONFIG_REL_OUT = {
+    'path': '/my/abs/path',
+    'path_out': 'path',
+}
+SPEC_CONFIG_REL_IO = {
+    'path': '/my/abs/path',
+    'path_out': '/my/abs/out/path',
+}
+SPEC_CONFIG_NO_OUT = {
+    'path': '/my/abs/path',
+}
+SPEC_CONFIG_REL_IN_NO_OUT = {
+    'path': 'path',
+}
+SPEC_CONFIG_NO_IN = {
+    'path_out': '/my/abs/out/path',
 }
 
 
@@ -84,3 +115,64 @@ def test_mongo_config_with_data():
     """Test creation of the MongoConfig model with data."""
     res = MongoConfig(**MONGO_CONFIG)
     assert isinstance(res, MongoConfig)
+
+
+def test_spec_config():
+    """Test creation of the SpecConfig model with valid data."""
+    res = SpecConfig(**SPEC_CONFIG)
+    assert isinstance(res, SpecConfig)
+    assert Path(res.path).is_absolute()
+    assert res.path_out is not None
+    assert Path(res.path_out).is_absolute()
+
+
+def test_spec_config_rel_in():
+    """Test creation of the SpecConfig model with relative input file path."""
+    res = SpecConfig(**SPEC_CONFIG_REL_IN)
+    assert isinstance(res, SpecConfig)
+    assert Path(res.path).is_absolute()
+    assert res.path_out is not None
+    assert Path(res.path_out).is_absolute()
+
+
+def test_spec_config_rel_out():
+    """Test creation of the SpecConfig model with relative output file path."""
+    res = SpecConfig(**SPEC_CONFIG_REL_OUT)
+    assert isinstance(res, SpecConfig)
+    assert Path(res.path).is_absolute()
+    assert res.path_out is not None
+    assert Path(res.path_out).is_absolute()
+
+
+def test_spec_config_rel_io():
+    """Test creation of the SpecConfig model with relative input and output
+    file paths."""
+    res = SpecConfig(**SPEC_CONFIG_REL_IO)
+    assert isinstance(res, SpecConfig)
+    assert Path(res.path).is_absolute()
+    assert res.path_out is not None
+    assert Path(res.path_out).is_absolute()
+
+
+def test_spec_config_no_out():
+    """Test creation of the SpecConfig model with valid data."""
+    res = SpecConfig(**SPEC_CONFIG_NO_OUT)
+    assert isinstance(res, SpecConfig)
+    assert Path(res.path).is_absolute()
+    assert res.path_out is not None
+    assert Path(res.path_out).is_absolute()
+
+
+def test_spec_config_rel_in_no_out():
+    """Test creation of the SpecConfig model with valid data."""
+    res = SpecConfig(**SPEC_CONFIG_REL_IN_NO_OUT)
+    assert isinstance(res, SpecConfig)
+    assert Path(res.path).is_absolute()
+    assert res.path_out is not None
+    assert Path(res.path_out).is_absolute()
+
+
+def test_spec_config_no_in():
+    """Test creation of the SpecConfig model with valid data."""
+    with pytest.raises(ValidationError):
+        SpecConfig(**SPEC_CONFIG_NO_IN)


### PR DESCRIPTION
## Description

Handle relative OpenAPI spec paths at the level of model validation, for both input and output spec file paths. Paths are resolved relative to caller's current working directory.

Improves on #61