### PR TITLE
build: install FOCA dev version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,10 @@ RUN pip install \
     --no-warn-script-location \
     --prefix="/install" \
     -r requirements.txt && \
-    pip install https://github.com/elixir-cloud-aai/foca/archive/dev.zip
+    pip install \
+    --no-warn-script-location \
+    --prefix="/install" \
+    https://github.com/elixir-cloud-aai/foca/archive/dev.zip
 
 # Final image
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ COPY ./requirements.txt .
 RUN pip install \
     --no-warn-script-location \
     --prefix="/install" \
-    -r requirements.txt
+    -r requirements.txt && \
+    pip install https://github.com/elixir-cloud-aai/foca/archive/dev.zip
 
 # Final image
 FROM base


### PR DESCRIPTION
## Description

Install latest FOCA version from `dev` branch in `Dockerfile` so that apps using FOCA will not need to install it.