### PR TITLE
feat(log): configure logging

### DIFF
--- a/foca/config/config_parser.py
+++ b/foca/config/config_parser.py
@@ -1,9 +1,14 @@
 """Parser for YAML-based app configuration."""
 
-import yaml
+import logging
+from logging.config import dictConfig
 from typing import (Dict, Optional)
 
-from foca.models.config import Config
+import yaml
+
+from foca.models.config import (Config, LogConfig)
+
+logger = logging.getLogger(__name__)
 
 
 class ConfigParser():
@@ -11,17 +16,37 @@ class ConfigParser():
 
     Args:
         config_file: Path to config file in YAML format.
+        format_logs: Whether log formatting should be configured.
 
     Attributes:
         config_file: Path to config file in YAML format.
+        format_logs: Whether log formatting should be configured.
     """
 
-    def __init__(self, config_file: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        config_file: Optional[str] = None,
+        format_logs: bool = True
+    ) -> None:
         """Constructor method."""
         if config_file:
             self.config = Config(**self.parse_yaml(config_file))
         else:
             self.config = Config()
+        if format_logs:
+            self.configure_logging()
+        logger.debug(f"Parsed config: {self.config.dict(by_alias=True)}")
+
+    def configure_logging(self) -> None:
+        """Configure logging."""
+        try:
+            dictConfig(self.config.log.dict(by_alias=True))
+        except Exception as e:
+            dictConfig(LogConfig().dict(by_alias=True))
+            logger.warning(
+                f"Failed to configure logging. Falling back to default "
+                f"settings. Original error: {type(e).__name__}: {e}"
+            )
 
     @staticmethod
     def parse_yaml(conf: str) -> Dict:

--- a/foca/errors/errors.py
+++ b/foca/errors/errors.py
@@ -34,7 +34,7 @@ def register_error_handlers(app: App) -> App:
     app.add_error_handler(InternalServerError, __handle_internal_server_error)
     app.add_error_handler(NotFound, __handle_not_found)
     app.add_error_handler(Unauthorized, __handle_unauthorized)
-    logger.info('Registered custom exception handlers with Connexion app.')
+    logger.debug('Registered custom exception handlers with Connexion app.')
 
     # Return Connexion app instance
     return app

--- a/foca/factories/celery_app.py
+++ b/foca/factories/celery_app.py
@@ -29,11 +29,11 @@ def create_celery_app(app: Flask) -> Celery:
         include=conf.include,
     )
     calling_module = ':'.join([stack()[1].filename, stack()[1].function])
-    logger.info(f"Celery app created from '{calling_module}'.")
+    logger.debug(f"Celery app created from '{calling_module}'.")
 
     # Update Celery app configuration with Flask app configuration
     celery.conf['FOCA'] = app.config['FOCA']
-    logger.info('Celery app configured.')
+    logger.debug('Celery app configured.')
 
     class ContextTask(celery.Task):  # type: ignore
         # https://github.com/python/mypy/issues/4284)

--- a/foca/factories/connexion_app.py
+++ b/foca/factories/connexion_app.py
@@ -19,7 +19,7 @@ def create_connexion_app(config: Optional[Config] = None) -> App:
     app = App(__name__)
 
     calling_module = ':'.join([stack()[1].filename, stack()[1].function])
-    logger.info(f"Connexion app created from '{calling_module}'.")
+    logger.debug(f"Connexion app created from '{calling_module}'.")
 
     # Workaround for adding a custom handler for `connexion.problem` responses
     # Responses from request and paramater validators are not raised and
@@ -77,5 +77,5 @@ def __add_config_to_connexion_app(
     # Add user configuration to Flask app config
     app.app.config['FOCA'] = config
 
-    logger.info('Connexion app configured.')
+    logger.debug('Connexion app configured.')
     return app

--- a/foca/foca.py
+++ b/foca/foca.py
@@ -28,9 +28,13 @@ def foca(config: Optional[str] = None) -> App:
     Returns:
         Connexion app instance.
     """
-    # Create a Config class instance for parameters validation
-    conf = ConfigParser(config).config
-    logger.info(f"Configuration file '{config}' parsed.")
+    # Parse config parameters and format logging
+    conf = ConfigParser(config, format_logs=True).config
+    logger.info(f"Log formatting configured.")
+    if config:
+        logger.info(f"Configuration file '{config}' parsed.")
+    else:
+        logger.info(f"Default app configuration used.")
 
     # Create Connexion app
     cnx_app = create_connexion_app(conf)
@@ -39,6 +43,19 @@ def foca(config: Optional[str] = None) -> App:
     # Register error handlers
     cnx_app = register_error_handlers(cnx_app)
     logger.info(f"Error handlers registered.")
+
+    # Enable cross-origin resource sharing
+    enable_cors(cnx_app.app)
+    logger.info(f"CORS enabled.")
+
+    # Register OpenAPI specs
+    if conf.api.specs:
+        cnx_app = register_openapi(
+            app=cnx_app,
+            specs=conf.api.specs,
+        )
+    else:
+        logger.info(f"No OpenAPI specifications provided.")
 
     # Register MongoDB
     if conf.db:
@@ -56,18 +73,5 @@ def foca(config: Optional[str] = None) -> App:
         logger.info(f"Support for background tasks set up.")
     else:
         logger.info(f"No support for background tasks configured.")
-
-    # Register OpenAPI specs
-    if conf.api.specs:
-        cnx_app = register_openapi(
-            app=cnx_app,
-            specs=conf.api.specs,
-        )
-    else:
-        logger.info(f"No OpenAPI specifications provided.")
-
-    # Enable cross-origin resource sharing
-    enable_cors(cnx_app.app)
-    logger.info(f"CORS enabled.")
 
     return cnx_app

--- a/foca/security/cors.py
+++ b/foca/security/cors.py
@@ -17,4 +17,4 @@ def enable_cors(app: Flask) -> None:
         app: Flask application.
     """
     CORS(app)
-    logger.info('Enabled CORS for Flask app.')
+    logger.debug('Enabled CORS for Flask app.')

--- a/tests/config/test_config_parser.py
+++ b/tests/config/test_config_parser.py
@@ -10,27 +10,35 @@ from foca.config.config_parser import ConfigParser
 from foca.models.config import Config
 
 
+TEST_CONFIG_INSTANCE = Config()
+TEST_DICT = {}
 TEST_FILE = "tests/test_files/conf_valid.yaml"
 TEST_FILE_INVALID = "tests/test_files/conf_invalid_log_level.yaml"
-TEST_DICT = {}
-TEST_CONFIG_INSTANCE = Config()
+TEST_FILE_INVALID_LOG = "tests/test_files/conf_log_invalid.yaml"
 
 
 def test_config_parser_valid_config_file():
-    """Test valid YAML parsing"""
+    """Test valid YAML parsing."""
     conf = ConfigParser(TEST_FILE)
     assert type(conf.config.dict()) == type(TEST_DICT)
     assert isinstance(conf.config, type(TEST_CONFIG_INSTANCE))
 
 
 def test_config_parser_invalid_config_file():
-    """Test valid YAML parsing"""
+    """Test invalid YAML parsing."""
     with pytest.raises(ValidationError):
         ConfigParser(TEST_FILE_INVALID)
 
 
 def test_config_parser_invalid_file_path():
-    """Test yaml class, passing invalid YAML file path"""
+    """Test invalid file path."""
     conf = ConfigParser(TEST_FILE)
     with pytest.raises(OSError):
         assert conf.parse_yaml("") is not None
+
+
+def test_config_parser_invalid_log_config():
+    """Test invalid log config YAML."""
+    conf = ConfigParser(TEST_FILE_INVALID_LOG)
+    assert type(conf.config.dict()) == type(TEST_DICT)
+    assert isinstance(conf.config, type(TEST_CONFIG_INSTANCE))

--- a/tests/test_files/conf_log.yaml
+++ b/tests/test_files/conf_log.yaml
@@ -1,0 +1,17 @@
+log:
+    version: 1
+    disable_existing_loggers: False
+    formatters:
+        standard:
+            class: logging.Formatter
+            style: "{"
+            format: "[{asctime}: {levelname:<8}] {message} [{name}]"
+    handlers:
+        console:
+            class: logging.StreamHandler
+            level: 20
+            formatter: standard
+            stream: ext://sys.stderr
+    root:
+        level: 10
+        handlers: [console]

--- a/tests/test_files/conf_log_invalid.yaml
+++ b/tests/test_files/conf_log_invalid.yaml
@@ -1,0 +1,17 @@
+log:
+    version: 1
+    disable_existing_loggers: False
+    formatters:
+        a!@#$:
+            class: logging.Formatter
+            style: "{"
+            format: "[{asctime}: {levelname:<8}] {message} [{name}]"
+    handlers:
+        console:
+            class: logging.StreamHandler
+            level: 20
+            formatter: standard
+            stream: ext://sys.stderr
+    root:
+        level: 10
+        handlers: [console]


### PR DESCRIPTION
## Description

- `YAMLConfigParser` class. optionally handles logging configuration.
- Enable logging configuration by config parser in main FOCA entry point.
- Fall back to default configuration if an invalid configuration is provided by the user.
- Lower log level of standard status messages in individual functional modules from `logging.INFO` to `logging.DEBUG`.
- At log level `logging.INFO`, only main FOCA entry point logs status messages
