### PR TITLE
ci: push Docker only after other tests have passed

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,6 +53,7 @@ jobs:
 
   Docker:
     runs-on: ubuntu-latest
+    needs: [Test]
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/elixir-cloud-aai/foca/issues/126).