### PR TITLE
feat: class-based FOCA entry point

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,7 +39,7 @@ jobs:
         run: flake8
       - name: Calculate unit test coverage
         run: |
-          coverage run --source foca -m pytest
+          coverage run --source foca -m pytest -W ignore::DeprecationWarning
           coverage xml
       - name: Submit Report to Codecov
         uses: codecov/codecov-action@v2

--- a/README.md
+++ b/README.md
@@ -67,12 +67,13 @@ pip install foca
 
 (2) Create a [configuration file](#configuration-file).
 
-(3) Import the FOCA main function `foca()` and pass your config:
+(3) Import the FOCA class and pass your config file:
 
 ```python
-from foca import foca
+from foca import Foca
 
-app = foca("path/to/my/app/config.yaml")  # returns a Connexion app instance
+app = Foca(config_file="path/to/my/app/config.yaml")
+app = foca.create_app()  # returns a Connexion app instance
 ```
 
 (4) Start your [Flask][res-flask] app as usual.
@@ -376,15 +377,16 @@ custom:
 ```
 
 You can then have FOCA validate your custom configuration against the
-`CustomConfig` class by including it in the `foca()` call like so:
+`CustomConfig` class by including it in the `Foca()` call like so:
 
 ```py
-from foca.foca import foca
+from foca import Foca
 
-my_app = foca(
+foca = Foca(
   config="my_app/config.yaml",
   custom_config_model="my_app.custom_config.CustomConfig",
 )
+my_app = foca.create_app()
 ```
 
 We recommend that, when defining your `pydantic` model, that you supply
@@ -403,7 +405,7 @@ simply attach these to your application instance as described
 [below](#accessing-configuration-parameters). Note, however, that any
 such parameters need to be _manually_ validated. The same is true if you
 include a `custom` section but do _not_ provide a validation model class via
-the `custom_config_model` parameter when calling `foca()`.
+the `custom_config_model` parameter when instantiating `Foca`.
 
 _Example:_
 

--- a/examples/petstore/app.py
+++ b/examples/petstore/app.py
@@ -1,6 +1,10 @@
-#!/usr/bin/env python3
-from foca.foca import foca
+"""Entry point for petstore example app."""
+
+from foca import Foca
 
 if __name__ == '__main__':
-    app = foca("config.yaml")
+    foca = Foca(
+        config_file="config.yaml"
+    )
+    app = foca.create_app()
     app.run()

--- a/examples/petstore/docker-compose.yaml
+++ b/examples/petstore/docker-compose.yaml
@@ -21,4 +21,4 @@ services:
     volumes:
       - ./data/petstore/db:/data/db
     ports:
-      - "27077:27017"
+      - "27017:27017"

--- a/foca/__init__.py
+++ b/foca/__init__.py
@@ -1,3 +1,5 @@
 """FOCA root package."""
 
+from foca.foca import Foca  # noqa: F401
+
 __version__ = '0.8.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+version = attr: foca.__version__
+
 [flake8]
 exclude = .git,.eggs,build,venv,env
 max-line-length = 79

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 import os
 from setuptools import setup, find_packages
 
-from foca import __version__
-
 root_dir = os.path.dirname(os.path.abspath(__file__))
 
 # Read long description from file
@@ -19,7 +17,6 @@ if os.path.isfile(req):
 
 setup(
     name="foca",
-    version=__version__,
     description=(
         "Archetype for OpenAPI microservices based on Flask and Connexion"
     ),

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -103,10 +103,10 @@ log:
 # Available in app context as attributes of `current_app.config.foca`
 
 # Can be validated by FOCA by passing a Pydantic model class to the
-# `custom_config_model` parameter in `foca.foca.foca`
+# `custom_config_model` parameter in the `foca.Foca()` constructor
 custom:
   my_param: 'some_value'
-  
+
 # Any other sections/parameters are *not* validated by FOCA; if desired,
 # validate parameters in app
 custom_params_not_validated:

--- a/tests/test_foca.py
+++ b/tests/test_foca.py
@@ -1,6 +1,6 @@
 """Tests for `foca.py` module."""
 
-import pathlib
+from pathlib import Path
 import pytest
 import shutil
 import os
@@ -14,9 +14,9 @@ from yaml import (
     safe_dump,
 )
 
-from foca.foca import foca
+from foca import Foca
 
-DIR = pathlib.Path(__file__).parent / "test_files"
+DIR = Path(__file__).parent / "test_files"
 PATH_SPECS_2_YAML_ORIGINAL = str(DIR / "openapi_2_petstore.original.yaml")
 PATH_SPECS_2_YAML_MODIFIED = str(DIR / "openapi_2_petstore.modified.yaml")
 PATH_SPECS_INVALID_OPENAPI = str(DIR / "invalid_openapi_2.yaml")
@@ -29,18 +29,18 @@ INVALID_LOG_CONF = str(DIR / "conf_invalid_log_level.yaml")
 JOBS_CONF = str(DIR / "conf_jobs.yaml")
 INVALID_JOBS_CONF = str(DIR / "conf_invalid_jobs.yaml")
 API_CONF = str(DIR / "conf_api.yaml")
-VALID_CORS_DIS_CONF = str(DIR / "conf_valid_cors_disabled.yaml")
-VALID_CORS_ENA_CONF = str(DIR / "conf_valid_cors_enabled.yaml")
+VALID_CORS_CONF_DISABLED = str(DIR / "conf_valid_cors_disabled.yaml")
+VALID_CORS_CONF_ENABLED = str(DIR / "conf_valid_cors_enabled.yaml")
 
 
-def create_temporary_copy(path, CONF):
+def create_modified_api_conf(path, temp_dir, api_specs_in, api_specs_out):
     """Create a copy of a configuration YAML file"""
-    temp_path = os.path.join(DIR, 'temp_test.yaml')
+    temp_path = Path(temp_dir) / 'temp_test.yaml'
     shutil.copy2(path, temp_path)
     with open(temp_path, 'r+') as conf_file:
         conf = safe_load(conf_file)
-        conf["api"]["specs"][0]["path"] = CONF
-        conf["api"]["specs"][0]["path_out"] = PATH_SPECS_2_YAML_MODIFIED
+        conf["api"]["specs"][0]["path"] = api_specs_in
+        conf["api"]["specs"][0]["path_out"] = api_specs_out
         conf_file.seek(0)
         safe_dump(conf, conf_file)
         conf_file.truncate()
@@ -49,55 +49,65 @@ def create_temporary_copy(path, CONF):
 
 def test_foca_output_defaults():
     """Ensure foca() returns a Connexion app instance; defaults only."""
-    app = foca()
+    foca = Foca()
+    app = foca.create_app()
     assert isinstance(app, App)
 
 
 def test_foca_empty_conf():
     """Ensure foca() require non-empty configuration parameters (if a field is
     present)"""
+    foca = Foca(config_file=EMPTY_CONF)
     with pytest.raises(ValidationError):
-        foca(EMPTY_CONF)
+        foca.create_app()
 
 
 def test_foca_invalid_structure():
     """Test foca(); invalid configuration file structure."""
+    foca = Foca(config_file=INVALID_CONF)
     with pytest.raises(ValueError):
-        foca(INVALID_CONF)
+        foca.create_app()
 
 
 def test_foca_invalid_log():
     """Test foca(); invalid log field"""
+    foca = Foca(config_file=INVALID_LOG_CONF)
     with pytest.raises(ValidationError):
-        foca(INVALID_LOG_CONF)
+        foca.create_app()
 
 
 def test_foca_jobs():
     """Ensure foca() returns a Connexion app instance; valid jobs field"""
-    app = foca(JOBS_CONF)
+    foca = Foca(config_file=JOBS_CONF)
+    app = foca.create_app()
     assert isinstance(app, App)
 
 
 def test_foca_invalid_jobs():
     """Test foca(); invalid jobs field"""
+    foca = Foca(config_file=INVALID_JOBS_CONF)
     with pytest.raises(ValidationError):
-        foca(INVALID_JOBS_CONF)
+        foca.create_app()
 
 
-def test_foca_api():
+def test_foca_api(tmpdir):
     """Ensure foca() returns a Connexion app instance; valid api field"""
-    temp_file = create_temporary_copy(
+    temp_file = create_modified_api_conf(
         API_CONF,
+        tmpdir,
         PATH_SPECS_2_YAML_ORIGINAL,
+        PATH_SPECS_2_YAML_MODIFIED,
     )
-    app = foca(temp_file)
+    foca = Foca(config_file=temp_file)
+    app = foca.create_app()
     assert isinstance(app, App)
     os.remove(temp_file)
 
 
 def test_foca_db():
     """Ensure foca() returns a Connexion app instance; valid db field"""
-    app = foca(VALID_DB_CONF)
+    foca = Foca(config_file=VALID_DB_CONF)
+    app = foca.create_app()
     my_db = app.app.config.foca.db.dbs['my-db']
     my_coll = my_db.collections['my-col-1']
     assert isinstance(my_db.client, Database)
@@ -107,17 +117,20 @@ def test_foca_db():
 
 def test_foca_invalid_db():
     """Test foca(); invalid db field"""
+    foca = Foca(config_file=INVALID_DB_CONF)
     with pytest.raises(ValidationError):
-        foca(INVALID_DB_CONF)
+        foca.create_app()
 
 
 def test_foca_CORS_enabled():
     """Ensures CORS is enabled for Microservice"""
-    app = foca(VALID_CORS_ENA_CONF)
+    foca = Foca(config_file=VALID_CORS_CONF_ENABLED)
+    app = foca.create_app()
     assert app.app.config.foca.security.cors.enabled is True
 
 
 def test_foca_CORS_disabled():
     """Ensures CORS is disabled if user explicitly mentions"""
-    app = foca(VALID_CORS_DIS_CONF)
+    foca = Foca(config_file=VALID_CORS_CONF_DISABLED)
+    app = foca.create_app()
     assert app.app.config.foca.security.cors.enabled is False


### PR DESCRIPTION
## Description

- Class-based implementation of FOCA entry point
- add import for `FOCA` class to main package
- Creating a FOCA-based app now done with:
  ```py
  from foca import Foca
  
  foca = Foca(...)
  my_app = foca.create_app()
  ```

Resolves #110 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage
