### PR TITLE
refactor: use pathlib.Path for file paths

### DIFF
--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -17,7 +17,7 @@ import sys
 
 from sphinx.ext import apidoc
 
-sys.path.insert(Path().parents[1].resolve())
+sys.path.insert(Path.cwd().resolve().parents[1])
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -12,12 +12,12 @@ from foca import __version__
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+from pathlib import Path
 import sys
 
 from sphinx.ext import apidoc
 
-sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(Path().parents[1].resolve())
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -17,7 +17,7 @@ import sys
 
 from sphinx.ext import apidoc
 
-sys.path.insert(Path.cwd().resolve().parents[1])
+sys.path.insert(0, Path.cwd().resolve().parents[1])
 
 
 # -- Project information -----------------------------------------------------

--- a/foca/__init__.py
+++ b/foca/__init__.py
@@ -2,4 +2,4 @@
 
 from foca.foca import Foca  # noqa: F401
 
-__version__ = '0.8.0'
+__version__ = '0.9.0'

--- a/foca/config/config_parser.py
+++ b/foca/config/config_parser.py
@@ -49,7 +49,7 @@ class ConfigParser():
 
     def __init__(
         self,
-        config_file: Optional[str] = None,
+        config_file: Optional[Path] = None,
         custom_config_model: Optional[str] = None,
         format_logs: bool = True
     ) -> None:
@@ -82,7 +82,7 @@ class ConfigParser():
             )
 
     @staticmethod
-    def parse_yaml(conf: str) -> Dict:
+    def parse_yaml(conf: Path) -> Dict:
         """Parse YAML file.
 
         Args:
@@ -109,7 +109,7 @@ class ConfigParser():
             ) from exc
 
     @staticmethod
-    def merge_yaml(*args: str) -> Optional[Dict]:
+    def merge_yaml(*args: Path) -> Optional[Dict]:
         """Parse and merge a set of YAML files.
 
         Merging is done iteratively, from the first, second to the n-th

--- a/foca/foca.py
+++ b/foca/foca.py
@@ -1,6 +1,7 @@
 """Class for setting up and initializing a FOCA-based microservice."""
 
 import logging
+from pathlib import Path
 from typing import Optional
 
 from connexion import App
@@ -21,7 +22,7 @@ class Foca:
 
     def __init__(
         self,
-        config_file: Optional[str] = None,
+        config_file: Optional[Path] = None,
         custom_config_model: Optional[str] = None,
     ) -> None:
         """Instantiate FOCA class.
@@ -58,8 +59,10 @@ class Foca:
                     parameters, so as to make it easier for others to
                     write/modify their app configuration.
         """
-        self.config_file = config_file
-        self.custom_config_model = custom_config_model
+        self.config_file: Optional[Path] = Path(
+            config_file
+        ) if config_file is not None else None
+        self.custom_config_model: Optional[str] = custom_config_model
 
     def create_app(self) -> App:
         """Set up and initialize FOCA-based microservice.

--- a/foca/models/config.py
+++ b/foca/models/config.py
@@ -6,7 +6,6 @@ from functools import reduce
 import importlib
 import operator
 from pathlib import Path
-import os
 from typing import (Any, Dict, List, Optional, Union)
 
 from pydantic import (BaseModel, Field, validator)  # pylint: disable=E0611
@@ -607,10 +606,7 @@ d': 'some_value'}, disable_auth=False, connexion=None)
         """
         if 'path' in values and values['path'] is not None:
             if not v:
-                return '.'.join([
-                    os.path.splitext(values['path'][0])[0],
-                    "modified.yaml"
-                ])
+                return f"{Path(values['path'][0]).stem}.modified.yaml"
             if not Path(v).is_absolute():
                 return str(Path.cwd() / v)
         return v

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,18 @@
-import os
+"""Package setup."""
+
+from pathlib import Path
 from setuptools import setup, find_packages
 
-root_dir = os.path.dirname(os.path.abspath(__file__))
+root_dir = Path(__file__).parent.resolve()
 
-# Read long description from file
-file_name = os.path.join(root_dir, "README.md")
-with open(file_name, "r") as fh:
-    long_description = fh.read()
+file_name = root_dir / "README.md"
+with open(file_name, "r") as _file:
+    long_description = _file.read()
 
-# Read requirements from file
 install_requires = []
-req = root_dir + '/requirements.txt'
-if os.path.isfile(req):
-    with open(req) as f:
-        install_requires = f.read().splitlines()
+req = root_dir / 'requirements.txt'
+with open(req, "r") as _file:
+    install_requires = _file.read().splitlines()
 
 setup(
     name="foca",

--- a/tests/api/test_register_openapi.py
+++ b/tests/api/test_register_openapi.py
@@ -14,16 +14,16 @@ from foca.api.register_openapi import register_openapi
 from foca.models.config import SpecConfig
 
 # Define mock data
-DIR = Path(__file__).parent.parent / "test_files"
-PATH_SPECS_2_YAML_ORIGINAL = str(DIR / "openapi_2_petstore.original.yaml")
-PATH_SPECS_2_YAML_MODIFIED = str(DIR / "openapi_2_petstore.modified.yaml")
-PATH_SPECS_2_JSON_ORIGINAL = str(DIR / "openapi_2_petstore.original.json")
-PATH_SPECS_2_YAML_ADDITION = str(DIR / "openapi_2_petstore.addition.yaml")
-PATH_SPECS_3_YAML_ORIGINAL = str(DIR / "openapi_3_petstore.original.yaml")
-PATH_SPECS_3_YAML_MODIFIED = str(DIR / "openapi_3_petstore.modified.yaml")
-PATH_SPECS_INVALID_JSON = str(DIR / "invalid.json")
-PATH_SPECS_INVALID_YAML = str(DIR / "invalid.openapi.yaml")
-PATH_NOT_FOUND = str(DIR / "does/not/exist.yaml")
+DIR = Path(__file__).parents[1].resolve() / "test_files"
+PATH_SPECS_2_YAML_ORIGINAL = DIR / "openapi_2_petstore.original.yaml"
+PATH_SPECS_2_YAML_MODIFIED = DIR / "openapi_2_petstore.modified.yaml"
+PATH_SPECS_2_JSON_ORIGINAL = DIR / "openapi_2_petstore.original.json"
+PATH_SPECS_2_YAML_ADDITION = DIR / "openapi_2_petstore.addition.yaml"
+PATH_SPECS_3_YAML_ORIGINAL = DIR / "openapi_3_petstore.original.yaml"
+PATH_SPECS_3_YAML_MODIFIED = DIR / "openapi_3_petstore.modified.yaml"
+PATH_SPECS_INVALID_JSON = DIR / "invalid.json"
+PATH_SPECS_INVALID_YAML = DIR / "invalid.openapi.yaml"
+PATH_NOT_FOUND = DIR / "does/not/exist.yaml"
 OPERATION_FIELDS_2 = {"x-swagger-router-controller": "controllers"}
 OPERATION_FIELDS_2_NO_RESOLVE = {"x-swagger-router-controller": YAMLError}
 OPERATION_FIELDS_3 = {"x-openapi-router-controller": "controllers"}

--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -366,19 +366,19 @@ def test_spec_config_list_no_out():
 def test_SpecConfig_full():
     """Test SpecConfig instantiation; full example"""
     res = SpecConfig(**SPEC_CONFIG)
-    assert res.path_out == SPEC_CONFIG['path_out']
+    assert str(res.path_out) == SPEC_CONFIG['path_out']
 
 
 def test_SpecConfig_minimal():
     """Test SpecConfig instantiation; minimal example"""
     res = SpecConfig(path=PATH)
-    assert res.path_out == PATH_MODIFIED
+    assert str(res.path_out) == PATH_MODIFIED
 
 
 def test_SpecConfig_merge():
     """Test SpecConfig instantiation; multiple config files"""
     res = SpecConfig(path=[PATH, PATH_ADDITION])
-    assert res.path_out == PATH_MODIFIED
+    assert str(res.path_out) == PATH_MODIFIED
 
 
 def test_SpecConfig_extra_arg():

--- a/tests/test_foca.py
+++ b/tests/test_foca.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 import pytest
 import shutil
-import os
 
 from connexion import App
 from pydantic import ValidationError
@@ -101,7 +100,6 @@ def test_foca_api(tmpdir):
     foca = Foca(config_file=temp_file)
     app = foca.create_app()
     assert isinstance(app, App)
-    os.remove(temp_file)
 
 
 def test_foca_db():


### PR DESCRIPTION
## Description

- use `pathlib.Path` for passing file paths and replacing operations from the `os` module
- bump version to `v0.9.0`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (or documentation does not need to be updated)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage

