### PR TITLE
tests(petstore-auth): fix 401 and 403 responses

### DIFF
--- a/examples/petstore-access-control/exceptions.py
+++ b/examples/petstore-access-control/exceptions.py
@@ -5,6 +5,7 @@ from connexion.exceptions import (
     ExtraParameterProblem,
     Forbidden,
     Unauthorized,
+    OAuthProblem,
 )
 from werkzeug.exceptions import (
     BadRequest,
@@ -14,35 +15,47 @@ from werkzeug.exceptions import (
 
 exceptions = {
     Exception: {
-        "message": "An unexpected error occurred.",
+        "message": "Oops, something unexpected happened.",
         "code": 500,
     },
     BadRequestProblem: {
-        "message": "The request is malformed",
+        "message": "We don't quite understand what it is you are looking for.",
         "code": 400,
     },
     BadRequest: {
-        "message": "The request is malformed.",
+        "message": "We don't quite understand what it is you are looking for.",
         "code": 400,
     },
     ExtraParameterProblem: {
-        "message": "The request is malformed.",
+        "message": "We don't quite understand what it is you are looking for.",
         "code": 400,
     },
+    OAuthProblem: {
+        "message": (
+            "I will need to see some identification first, before I let you "
+            "play with the pets."
+        ),
+        "code": 401,
+    },
     Unauthorized: {
-        "message": "The request is unauthorized.",
+        "message": (
+            "We will need to see some identification before we let you play "
+            "with the pets."
+        ),
         "code": 401,
     },
     Forbidden: {
-        "message": "The requester is not authorized to perform this action.",
+        "message": (
+            "Sorry, but you don't have permission to play with the pets."
+        ),
         "code": 403,
     },
     NotFound: {
-        "message": "The requested resource wasn't found.",
+        "message": "We have never heard of this pet! :-(",
         "code": 404,
     },
     InternalServerError: {
-        "message": "An unexpected error occurred.",
+        "message": "We seem to be having a problem here in the petstore.",
         "code": 500,
-    }
+    },
 }

--- a/examples/petstore/exceptions.py
+++ b/examples/petstore/exceptions.py
@@ -8,19 +8,19 @@ from werkzeug.exceptions import (
 
 exceptions = {
     Exception: {
-        "message": "An unexpected error occurred.",
+        "message": "Oops, something unexpected happened.",
         "code": 500,
     },
     BadRequestProblem: {
-        "message": "The request is malformed.",
+        "message": "We don't quite understand what it is you are looking for.",
         "code": 400,
     },
     NotFound: {
-        "message": "The requested resource wasn't found.",
+        "message": "We have never heard of this pet! :-(",
         "code": 404,
     },
     InternalServerError: {
-        "message": "An unexpected error occurred.",
+        "message": "We seem to be having a problem here in the petstore.",
         "code": 500,
     },
 }


### PR DESCRIPTION
## Description

For the authenticated petstore example, set expected responses:
- `401`: add `connexion.exceptions.OAuthProblem` to exceptions dictionary, as this is what `connexion` raises (not `connexion.exceptions.Unauthorized`)
- `403`: have decorator `foca.access_control.register_access_control.check_permissions` throw `connexion.exceptions.Forbidden` when Casbin enforcer blocks access, rather than returning the default response - a tuple of `flask.wrappers.Response` and a `401` status code of type `int`.

Changes also update the messages for all exceptions in the petstore and petstore-auth examples to keep the tone and analogies of the petstore app. This is to highlight how easy exception handling becomes with FOCA and also, hopefully, to make the examples more accessible.
