### PR TITLE
fix: import issues due to version imports

### DIFF
--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -1,4 +1,4 @@
-from foca import __version__
+from foca.version import __version__
 
 # Configuration file for the Sphinx documentation builder.
 #

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -17,8 +17,11 @@ import sys
 
 from sphinx.ext import apidoc
 
-sys.path.insert(0, Path.cwd().resolve().parents[1])
+root_dir = Path.cwd().resolve().parents[1]
 
+sys.path.insert(0, root_dir)
+
+exec(open(root_dir / "foca" / "version.py"))
 
 # -- Project information -----------------------------------------------------
 
@@ -27,7 +30,7 @@ copyright = '2020, ELIXIR Cloud & AAI'
 author = 'ELIXIR Cloud & AAI'
 
 # The full version, including alpha/beta/rc tags
-release = __version__
+release = __version__  # noqa: F821
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -1,5 +1,3 @@
-from foca.version import __version__
-
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -19,7 +19,7 @@ root_dir = Path.cwd().resolve().parents[1]
 
 sys.path.insert(0, root_dir)
 
-exec(open(root_dir / "foca" / "version.py"))
+exec(open(root_dir / "foca" / "version.py").read())
 
 # -- Project information -----------------------------------------------------
 

--- a/foca/__init__.py
+++ b/foca/__init__.py
@@ -1,5 +1,3 @@
 """FOCA root package."""
 
 from foca.foca import Foca  # noqa: F401
-
-__version__ = '0.9.0'

--- a/foca/version.py
+++ b/foca/version.py
@@ -1,0 +1,3 @@
+"""Single source of truth for package version."""
+
+__version__ = '0.9.0'

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@
 from pathlib import Path
 from setuptools import setup, find_packages
 
-exec(open('foca/version.py').read())
-
 root_dir = Path(__file__).parent.resolve()
+
+exec(open(root_dir / "foca" / "version.py").read())
 
 file_name = root_dir / "README.md"
 with open(file_name, "r") as _file:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(req, "r") as _file:
 
 setup(
     name="foca",
-    version=__version__,
+    version=__version__,  # noqa: F821
     description=(
         "Archetype for OpenAPI microservices based on Flask and Connexion"
     ),

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from setuptools import setup, find_packages
 
+exec(open('foca/version.py').read())
+
 root_dir = Path(__file__).parent.resolve()
 
 file_name = root_dir / "README.md"
@@ -16,6 +18,7 @@ with open(req, "r") as _file:
 
 setup(
     name="foca",
+    version=__version__,
     description=(
         "Archetype for OpenAPI microservices based on Flask and Connexion"
     ),

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,3 @@
+"""Tests for `version.py` module."""
+
+from foca.version import __version__

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,3 +1,3 @@
 """Tests for `version.py` module."""
 
-from foca.version import __version__
+from foca.version import __version__  # noqa: F401


### PR DESCRIPTION
## Description

- store `__version__` string in module `foca.version` rather than in `foca`
- change version string import in Sphinx config (`docs/api/conf.py`)
- import version string in `setup.py` via `exec()` and use in `setup()`

Fixes #151 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update