### PR TITLE
fix: add database config to Celery app

### DIFF
--- a/foca/foca.py
+++ b/foca/foca.py
@@ -174,6 +174,16 @@ class Foca:
         cnx_app = register_exception_handler(cnx_app)
         logger.info("Error handler registered.")
 
+        # Register MongoDB
+        if self.conf.db:
+            cnx_app.app.config.foca.db = register_mongodb(
+                app=cnx_app.app,
+                conf=self.conf.db,
+            )
+            logger.info("Database registered.")
+        else:
+            logger.info("No database support configured.")
+
         # Create Celery app
         if self.conf.jobs:
             celery_app = create_celery_app(cnx_app.app)

--- a/foca/version.py
+++ b/foca/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for package version."""
 
-__version__ = '0.11.0'
+__version__ = '0.12.0'


### PR DESCRIPTION
- register Celery app with database in `Foca.create_celery_app()` 
- bump version to `v0.12.0`

Fixes #161