### PR TITLE
docs: add Read the Docs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,32 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/api/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+python:
+   install:
+   - requirements: docs/api/requirements.txt

--- a/docs/api/requirements.txt
+++ b/docs/api/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx==7.2.6
+readthedocs-sphinx-ext==2.2.3
+sphinx-rtd-theme==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 addict==2.2.1
 celery==5.2.2
-connexion>=2.11.2
+connexion>=2.11.2,<3.0.0
 cryptography==41.0.3
 Flask==2.2.5
 flask-authz==2.5.0


### PR DESCRIPTION
## Description

- Add Read the Docs config (v2) recently [made mandatory](https://blog.readthedocs.com/migrate-configuration-v2/)
- Provide specific requirements for API doc generation

Fixes #165 

## Type of change

- [x] Documentation update