### PR TITLE
fix: register custom config model

### DIFF
--- a/foca/models/config.py
+++ b/foca/models/config.py
@@ -718,7 +718,7 @@ nf', owner_headers={'X-User', 'X-Group'}, user_headers={'X-User'})
 
         model_path = Path(v)
         if not model_path.is_absolute():
-            return str(Path.cwd() / model_path)
+            return str(model_path.resolve())
 
         return v
 

--- a/foca/models/config.py
+++ b/foca/models/config.py
@@ -8,10 +8,15 @@ import operator
 from pathlib import Path
 from typing import (Any, Dict, List, Optional, Union)
 
+from pkg_resources import resource_filename
+
 from pydantic import (BaseModel, Field, validator)  # pylint: disable=E0611
 import pymongo
 
-from foca.security.access_control.constants import DEFAULT_MODEL_FILE
+from foca.security.access_control.constants import (
+    ACCESS_CONTROL_BASE_PATH,
+    DEFAULT_MODEL_FILE
+)
 
 
 def _validate_log_level_choices(level: int) -> int:
@@ -693,9 +698,29 @@ nf', owner_headers={'X-User', 'X-Group'}, user_headers={'X-User'})
     api_controllers: Optional[str] = None
     db_name: Optional[str] = None
     collection_name: Optional[str] = None
-    model: Optional[str] = DEFAULT_MODEL_FILE
+    model: Optional[str] = None
     owner_headers: Optional[set] = None
     user_headers: Optional[set] = None
+
+    @validator('model', always=True, allow_reuse=True)
+    def validate_model_path(cls, v: Optional[Path]):  # pylint: disable=E0213
+        """
+        Resolve path relative to caller's current working directory if no
+        absolute path provided for model or Set to default file path for model
+        if path is not provided.
+        """
+        if v is None:
+            return str(
+                resource_filename(
+                    ACCESS_CONTROL_BASE_PATH, DEFAULT_MODEL_FILE
+                )
+            )
+
+        model_path = Path(v)
+        if not model_path.is_absolute():
+            return str(Path.cwd() / model_path)
+
+        return v
 
 
 class AuthConfig(FOCABaseConfig):

--- a/foca/security/access_control/register_access_control.py
+++ b/foca/security/access_control/register_access_control.py
@@ -155,13 +155,7 @@ def register_casbin_enforcer(
         Connexion application instance with registered casbin configuration.
     """
     # Check if default, get package path variables for model.
-    access_control_config_model = str(access_control_config.model)
-    if access_control_config.api_specs is None:
-        casbin_model = str(resource_filename(
-            ACCESS_CONTROL_BASE_PATH, access_control_config_model
-        ))
-    else:
-        casbin_model = access_control_config_model
+    casbin_model = access_control_config.model
 
     logger.info("Setting casbin model.")
     app.app.config["CASBIN_MODEL"] = casbin_model

--- a/tests/security/access_control/test_access_control_server.py
+++ b/tests/security/access_control/test_access_control_server.py
@@ -19,7 +19,9 @@ from foca.security.access_control.access_control_server import (
     putPermission
 )
 from foca.security.access_control.foca_casbin_adapter.adapter import Adapter
-from foca.security.access_control.constants import ACCESS_CONTROL_BASE_PATH, DEFAULT_MODEL_FILE
+from foca.security.access_control.constants import (
+    ACCESS_CONTROL_BASE_PATH, DEFAULT_MODEL_FILE
+)
 from foca.errors.exceptions import BadRequest, InternalServerError, NotFound
 from foca.models.config import (AccessControlConfig, Config, MongoConfig)
 
@@ -352,7 +354,6 @@ class TestModelPathResolution(TestCase):
         )
         assert config.model == default_model_path
 
-
     def test_relative_path_model_input(self):
         file_path = "access_model.conf"
         config = AccessControlConfig(model=file_path)
@@ -368,4 +369,3 @@ class TestModelPathResolution(TestCase):
         config = AccessControlConfig(model=file_path)
         assert config.model == file_path
         assert config.model == os.path.abspath(file_path)
-

--- a/tests/security/access_control/test_access_control_server.py
+++ b/tests/security/access_control/test_access_control_server.py
@@ -2,8 +2,12 @@
 
 from copy import deepcopy
 from unittest import TestCase
+
+
 from flask import Flask
 import mongomock
+import os
+from pkg_resources import resource_filename
 from pymongo import MongoClient
 import pytest
 
@@ -15,8 +19,10 @@ from foca.security.access_control.access_control_server import (
     putPermission
 )
 from foca.security.access_control.foca_casbin_adapter.adapter import Adapter
+from foca.security.access_control.constants import ACCESS_CONTROL_BASE_PATH, DEFAULT_MODEL_FILE
 from foca.errors.exceptions import BadRequest, InternalServerError, NotFound
 from foca.models.config import (AccessControlConfig, Config, MongoConfig)
+
 from tests.mock_data import (
     ACCESS_CONTROL_CONFIG,
     MOCK_ID,
@@ -332,3 +338,34 @@ class TestPutPermission(BaseTestAccessControl):
         with app.test_request_context(json=""):
             with pytest.raises(BadRequest):
                 putPermission.__wrapped__(id=MOCK_ID)
+
+
+class TestModelPathResolution(TestCase):
+    """Test class for checking access control model input resolution"""
+
+    def test_no_model_input(self):
+        config = AccessControlConfig()
+        default_model_path = str(
+            resource_filename(
+                ACCESS_CONTROL_BASE_PATH, DEFAULT_MODEL_FILE
+            )
+        )
+        assert config.model == default_model_path
+
+
+    def test_relative_path_model_input(self):
+        file_path = "access_model.conf"
+        config = AccessControlConfig(model=file_path)
+        assert config.model == os.path.abspath(file_path)
+
+        # testing relative paths with relative parent directory notation used
+        file_path = "../../test/access_model.conf"
+        config = AccessControlConfig(model=file_path)
+        assert config.model == os.path.abspath(file_path)
+
+    def test_absolute_path_model_input(self):
+        file_path = "/test/access_model.conf"
+        config = AccessControlConfig(model=file_path)
+        assert config.model == file_path
+        assert config.model == os.path.abspath(file_path)
+


### PR DESCRIPTION
## Description

This PR fixes the bug where foca did not register a custom config model which is passed in the input config if the api specs were not provided.
In addition, the validator for model path also converts the relative path passed in the config.yaml to the absolute path because casbin is not able to resolve relative path directly.

Fixes #181

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)