### PR TITLE
refactor: do not write out modified specs

### DIFF
--- a/foca/api/register_openapi.py
+++ b/foca/api/register_openapi.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Dict, List
 
 from connexion import App
-# import yaml
 
 from foca.models.config import SpecConfig
 from foca.config.config_parser import ConfigParser
@@ -85,21 +84,6 @@ def register_openapi(
                 for operation_object in path_item_object.values():
                     operation_object.pop('security', None)
             logger.debug("Removed security fields")
-
-        # Write modified specs
-        # try:
-        #     with open(spec.path_out, 'w') as out_file:  # type: ignore
-        #         yaml.safe_dump(spec_parsed, out_file)
-        # except OSError as e:
-        #     raise OSError(
-        #         "Modified specification could not be written to file "
-        #         f"'{spec.path_out}'"
-        #     ) from e
-        # except yaml.YAMLError as e:
-        #     raise yaml.YAMLError(
-        #         "Could not encode modified specification"
-        #     ) from e
-        # logger.debug(f"Wrote specs to file: {spec.path_out}")
 
         # Attach specs to connexion App
         logger.debug(f"Modified specs: {spec_parsed}")

--- a/foca/api/register_openapi.py
+++ b/foca/api/register_openapi.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from connexion import App
-import yaml
+# import yaml
 
 from foca.models.config import SpecConfig
 from foca.config.config_parser import ConfigParser
@@ -87,25 +87,25 @@ def register_openapi(
             logger.debug("Removed security fields")
 
         # Write modified specs
-        try:
-            with open(spec.path_out, 'w') as out_file:  # type: ignore
-                yaml.safe_dump(spec_parsed, out_file)
-        except OSError as e:
-            raise OSError(
-                "Modified specification could not be written to file "
-                f"'{spec.path_out}'"
-            ) from e
-        except yaml.YAMLError as e:
-            raise yaml.YAMLError(
-                "Could not encode modified specification"
-            ) from e
-        logger.debug(f"Wrote specs to file: {spec.path_out}")
+        # try:
+        #     with open(spec.path_out, 'w') as out_file:  # type: ignore
+        #         yaml.safe_dump(spec_parsed, out_file)
+        # except OSError as e:
+        #     raise OSError(
+        #         "Modified specification could not be written to file "
+        #         f"'{spec.path_out}'"
+        #     ) from e
+        # except yaml.YAMLError as e:
+        #     raise yaml.YAMLError(
+        #         "Could not encode modified specification"
+        #     ) from e
+        # logger.debug(f"Wrote specs to file: {spec.path_out}")
 
         # Attach specs to connexion App
         logger.debug(f"Modified specs: {spec_parsed}")
         spec.connexion = {} if spec.connexion is None else spec.connexion
         app.add_api(
-            specification=spec.path_out,
+            specification=spec_parsed,
             **spec.dict().get('connexion', {}),
         )
         logger.info(f"API endpoints added from spec: {spec.path_out}")

--- a/tests/api/test_register_openapi.py
+++ b/tests/api/test_register_openapi.py
@@ -150,27 +150,6 @@ class TestRegisterOpenAPI:
         res = register_openapi(app=app, specs=spec_configs)
         assert isinstance(res, App)
 
-    # def test_register_openapi_spec_cannot_serialize(self):
-    #   """Registration failing because modified specs cannot be serialized."""
-    #     app = App(__name__)
-    #     spec_configs = [SpecConfig(
-    #         path=PATH_SPECS_2_YAML_ORIGINAL,
-    #         path_out=PATH_SPECS_2_YAML_MODIFIED,
-    #         add_operation_fields=OPERATION_FIELDS_2_NO_RESOLVE,
-    #     )]
-    #     with pytest.raises(YAMLError):
-    #         register_openapi(app=app, specs=spec_configs)
-
-    # def test_register_openapi_spec_cannot_write(self):
-    #     """Registration failing because modified specs cannot be written."""
-    #     app = App(__name__)
-    #     spec_configs = [SpecConfig(
-    #         path=PATH_SPECS_2_YAML_ORIGINAL,
-    #         path_out=PATH_NOT_FOUND,
-    #     )]
-    #     with pytest.raises(OSError):
-    #         register_openapi(app=app, specs=spec_configs)
-
     def test_openapi_2_yaml_no_auth(self):
         """Successfully register OpenAPI 2 YAML specs with Connexion app;
         no security definitions/fields.

--- a/tests/api/test_register_openapi.py
+++ b/tests/api/test_register_openapi.py
@@ -150,26 +150,26 @@ class TestRegisterOpenAPI:
         res = register_openapi(app=app, specs=spec_configs)
         assert isinstance(res, App)
 
-    def test_register_openapi_spec_cannot_serialize(self):
-        """Registration failing because modified specs cannot be serialized."""
-        app = App(__name__)
-        spec_configs = [SpecConfig(
-            path=PATH_SPECS_2_YAML_ORIGINAL,
-            path_out=PATH_SPECS_2_YAML_MODIFIED,
-            add_operation_fields=OPERATION_FIELDS_2_NO_RESOLVE,
-        )]
-        with pytest.raises(YAMLError):
-            register_openapi(app=app, specs=spec_configs)
+    # def test_register_openapi_spec_cannot_serialize(self):
+    #   """Registration failing because modified specs cannot be serialized."""
+    #     app = App(__name__)
+    #     spec_configs = [SpecConfig(
+    #         path=PATH_SPECS_2_YAML_ORIGINAL,
+    #         path_out=PATH_SPECS_2_YAML_MODIFIED,
+    #         add_operation_fields=OPERATION_FIELDS_2_NO_RESOLVE,
+    #     )]
+    #     with pytest.raises(YAMLError):
+    #         register_openapi(app=app, specs=spec_configs)
 
-    def test_register_openapi_spec_cannot_write(self):
-        """Registration failing because modified specs cannot be written."""
-        app = App(__name__)
-        spec_configs = [SpecConfig(
-            path=PATH_SPECS_2_YAML_ORIGINAL,
-            path_out=PATH_NOT_FOUND,
-        )]
-        with pytest.raises(OSError):
-            register_openapi(app=app, specs=spec_configs)
+    # def test_register_openapi_spec_cannot_write(self):
+    #     """Registration failing because modified specs cannot be written."""
+    #     app = App(__name__)
+    #     spec_configs = [SpecConfig(
+    #         path=PATH_SPECS_2_YAML_ORIGINAL,
+    #         path_out=PATH_NOT_FOUND,
+    #     )]
+    #     with pytest.raises(OSError):
+    #         register_openapi(app=app, specs=spec_configs)
 
     def test_openapi_2_yaml_no_auth(self):
         """Successfully register OpenAPI 2 YAML specs with Connexion app;


### PR DESCRIPTION
## Description

Fixes #158

I just tried directly passing `spec_parsed` instead of writing it in a file.

Two test cases failed which were:

```
    def test_register_openapi_spec_cannot_serialize(self):
        """Registration failing because modified specs cannot be serialized."""
        app = App(__name__)
        spec_configs = [SpecConfig(
            path=PATH_SPECS_2_YAML_ORIGINAL,
            path_out=PATH_SPECS_2_YAML_MODIFIED,
            add_operation_fields=OPERATION_FIELDS_2_NO_RESOLVE,
        )]
        with pytest.raises(YAMLError):
            register_openapi(app=app, specs=spec_configs)

    def test_register_openapi_spec_cannot_write(self):
        """Registration failing because modified specs cannot be written."""
        app = App(__name__)
        spec_configs = [SpecConfig(
            path=PATH_SPECS_2_YAML_ORIGINAL,
            path_out=PATH_NOT_FOUND,
        )]
        with pytest.raises(OSError):
            register_openapi(app=app, specs=spec_configs)
```

These cases are about `modified_specs` but since directly passing the dictionary does not allow the creation of a new `.yaml` file. I think these might not be of the best use.

This will solve the deployment problem also mentioned in #158 as there is no need to create a file with write permissions.
I have also pushed the code that was being discussed in #158 in the branch name `modified_specs_storage`. I will be making a PR from that also so that a better one can be merged.

Please let me know if I am wrong or if I missed something :)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation (or documentation does not need to be updated)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have not reduced the existing code coverage

