### PR TITLE
build: add py3.11 support; use Debian 11

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -84,7 +84,7 @@ jobs:
         py-version-img-tag: [
           ["3.8", "3.8-slim-buster", ""],
           ["3.9", "3.9-slim-buster", ""],
-          ["3.10", "3.10-slim-buster", "latest"],
+          ["3.10", "3.10-slim-buster", ""],
           ["3.11", "3.11-slim-buster", "latest"],
         ]
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,6 +22,8 @@ jobs:
           ["3.8", "3.8-slim-buster"],
           ["3.9", "3.9-slim-buster"],
           ["3.10", "3.10-slim-buster"],
+          ["3.11", "3.11-slim-buster"],
+          ["3.12", "3.12-slim-buster"],
         ]
         mongodb-version: ["4.2", "4.4", "5.0"]
         mongodb-port: [12345]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,10 +19,10 @@ jobs:
       fail-fast: true
       matrix:
         py-version-img: [
-          ["3.8", "3.8-slim-buster"],
-          ["3.9", "3.9-slim-buster"],
-          ["3.10", "3.10-slim-buster"],
-          ["3.11", "3.11-slim-buster"]
+          ["3.8", "3.8-slim-bullseye"],
+          ["3.9", "3.9-slim-bullseye"],
+          ["3.10", "3.10-slim-bullseye"],
+          ["3.11", "3.11-slim-bullseye"]
         ]
         mongodb-version: ["4.2", "4.4", "5.0"]
         mongodb-port: [12345]
@@ -82,10 +82,10 @@ jobs:
       fail-fast: true
       matrix:
         py-version-img-tag: [
-          ["3.8", "3.8-slim-buster", ""],
-          ["3.9", "3.9-slim-buster", ""],
-          ["3.10", "3.10-slim-buster", ""],
-          ["3.11", "3.11-slim-buster", "latest"],
+          ["3.8", "3.8-slim-bullseye", ""],
+          ["3.9", "3.9-slim-bullseye", ""],
+          ["3.10", "3.10-slim-bullseye", ""],
+          ["3.11", "3.11-slim-bullseye", "latest"],
         ]
 
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,8 +22,7 @@ jobs:
           ["3.8", "3.8-slim-buster"],
           ["3.9", "3.9-slim-buster"],
           ["3.10", "3.10-slim-buster"],
-          ["3.11", "3.11-slim-buster"],
-          ["3.12", "3.12-slim-buster"],
+          ["3.11", "3.11-slim-buster"]
         ]
         mongodb-version: ["4.2", "4.4", "5.0"]
         mongodb-port: [12345]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -85,6 +85,7 @@ jobs:
           ["3.8", "3.8-slim-buster", ""],
           ["3.9", "3.9-slim-buster", ""],
           ["3.10", "3.10-slim-buster", "latest"],
+          ["3.11", "3.11-slim-buster", "latest"],
         ]
 
     steps:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG PY_IMAGE=3.10-slim-buster
+ARG PY_IMAGE=3.11-slim-bullseye
 FROM python:$PY_IMAGE as base
 
 # Metadata

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: System :: Systems Administration",
         "Topic :: Utilities",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: System :: Systems Administration",
         "Topic :: Utilities",


### PR DESCRIPTION
## Description

I tried building `foca` locally with `3.11` and `3.12`. There were no errors in requirements or dependencies 
I have also added versions in [checks.yml](https://github.com/elixir-cloud-aai/foca/blob/pyVersion/.github/workflows/checks.yml#L25-L26)

Fixes #174 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation (or documentation does not need to be updated)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have not reduced the existing code coverage

