### PR TITLE
build: upgrade base image & MongoDB; drop py3.8

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: true
       matrix:
         py-version-img: [
-          ["3.8", "3.8-slim-bookworm"],
           ["3.9", "3.9-slim-bookworm"],
           ["3.10", "3.10-slim-bookworm"],
           ["3.11", "3.11-slim-bookworm"]
@@ -82,7 +81,6 @@ jobs:
       fail-fast: true
       matrix:
         py-version-img-tag: [
-          ["3.8", "3.8-slim-bookworm", ""],
           ["3.9", "3.9-slim-bookworm", ""],
           ["3.10", "3.10-slim-bookworm", ""],
           ["3.11", "3.11-slim-bookworm", "latest"],

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ jobs:
           ["3.10", "3.10-slim-bookworm"],
           ["3.11", "3.11-slim-bookworm"]
         ]
-        mongodb-version: ["4.2", "4.4", "5.0"]
+        mongodb-version: ["4.4", "5.0", "6.0", "7.0"]
         mongodb-port: [12345]
 
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,10 +19,10 @@ jobs:
       fail-fast: true
       matrix:
         py-version-img: [
-          ["3.8", "3.8-slim-bullseye"],
-          ["3.9", "3.9-slim-bullseye"],
-          ["3.10", "3.10-slim-bullseye"],
-          ["3.11", "3.11-slim-bullseye"]
+          ["3.8", "3.8-slim-bookworm"],
+          ["3.9", "3.9-slim-bookworm"],
+          ["3.10", "3.10-slim-bookworm"],
+          ["3.11", "3.11-slim-bookworm"]
         ]
         mongodb-version: ["4.2", "4.4", "5.0"]
         mongodb-port: [12345]
@@ -82,10 +82,10 @@ jobs:
       fail-fast: true
       matrix:
         py-version-img-tag: [
-          ["3.8", "3.8-slim-bullseye", ""],
-          ["3.9", "3.9-slim-bullseye", ""],
-          ["3.10", "3.10-slim-bullseye", ""],
-          ["3.11", "3.11-slim-bullseye", "latest"],
+          ["3.8", "3.8-slim-bookworm", ""],
+          ["3.9", "3.9-slim-bookworm", ""],
+          ["3.10", "3.10-slim-bookworm", ""],
+          ["3.11", "3.11-slim-bookworm", "latest"],
         ]
 
     steps:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG PY_IMAGE=3.11-slim-bullseye
+ARG PY_IMAGE=3.11-slim-bookworm
 FROM python:$PY_IMAGE as base
 
 # Metadata

--- a/examples/petstore-access-control/README.md
+++ b/examples/petstore-access-control/README.md
@@ -77,11 +77,11 @@ Some notes:
 > version of Python, you can set the Python image to be used as FOCA's base
 > image by defining the environment variable `PETSTORE_PY_IMAGE` before
 > executing the build command. For example:
->  
+>
 >    ```bash
->    export PETSTORE_PY_IMAGE=3.8-slim-buster
+>    export PETSTORE_PY_IMAGE=3.11-slim-bookworm
 >    ```
->  
+>
 > * In case Docker complains about port conflicts or if any of the used ports
 > are blocked by a firewall, you will need to re-map the conflicting port(s) in
 > the [Docker Compose config][app-docker-compose]. In particular, for each of

--- a/examples/petstore/README.md
+++ b/examples/petstore/README.md
@@ -75,11 +75,11 @@ Some notes:
 > version of Python, you can set the Python image to be used as FOCA's base
 > image by defining the environment variable `PETSTORE_PY_IMAGE` before
 > executing the build command. For example:
->  
+>
 >    ```bash
->    export PETSTORE_PY_IMAGE=3.8-slim-buster
+>    export PETSTORE_PY_IMAGE=3.11-slim-bookworm
 >    ```
->  
+>
 > * In case Docker complains about port conflicts or if any of the used ports
 > are blocked by a firewall, you will need to re-map the conflicting port(s) in
 > the [Docker Compose config][app-docker-compose]. In particular, for each of

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Description

- Drop support for Python 3.8
- Upgrade Docker base image from Debian 11 "Bullseye" to Debian 12 "Bookworm"
- Add support for MongoDB versions "6.0" and "7.0" in CI
- Drop support for MongoDB version "4.2" from CI

Fixes #224
Fixes #226 
Fixes #227

## Type of change

Please delete options that are not relevant.

- [x] Build update

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation (or documentation does not need to be updated)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage