### PR TITLE
feat(db): support MONGO_URI for db creation

### DIFF
--- a/foca/api/register_openapi.py
+++ b/foca/api/register_openapi.py
@@ -58,7 +58,10 @@ def register_openapi(
             )
 
         # Add fields to security definitions/schemes
-        if not spec.disable_auth and spec.add_security_fields is not None:
+        if (
+            not spec.disable_auth
+            and spec.add_security_fields is not None
+        ):
             for key, val in spec.add_security_fields.items():
                 # OpenAPI 2
                 sec_defs = spec_parsed.get('securityDefinitions', {})

--- a/foca/database/register_mongodb.py
+++ b/foca/database/register_mongodb.py
@@ -6,6 +6,7 @@ import os
 from flask import Flask
 from flask_pymongo import PyMongo
 from foca.models.config import MongoConfig, DBConfig
+from urllib.parse import urlparse, urlunparse
 
 # Get logger instance
 logger = logging.getLogger(__name__)
@@ -123,6 +124,37 @@ def _create_mongo_client(
     Returns:
         MongoDB client for Flask application instance.
     """
+    # If full URI provided, prefer it over component-based construction
+    provided_uri = os.environ.get('MONGO_URI')
+    if provided_uri:
+        db_override = os.environ.get('MONGO_DBNAME')
+        if db_override:
+            try:
+                parsed = urlparse(provided_uri)
+                # Replace/insert path component with overridden db name
+                new_path = f"/{db_override}"
+                provided_uri = urlunparse((
+                    parsed.scheme,
+                    parsed.netloc,
+                    new_path,
+                    parsed.params,
+                    parsed.query,
+                    parsed.fragment,
+                ))
+            except Exception:
+                # In case of any parsing issues, fall back to using the
+                # provided URI as-is; PyMongo will validate later.
+                pass
+        app.config['MONGO_URI'] = provided_uri
+        mongo = PyMongo(app)
+        logger.info(
+            "Registered database '{db}' using provided MONGO_URI.".format(
+                db=os.environ.get('MONGO_DBNAME', db)
+            )
+        )
+        return mongo
+
+    # Fall back to legacy component-based construction
     auth = ''
     user = os.environ.get('MONGO_USERNAME')
     if user is not None and user != "":

--- a/tests/api/test_register_openapi.py
+++ b/tests/api/test_register_openapi.py
@@ -24,11 +24,19 @@ PATH_SPECS_3_YAML_MODIFIED = DIR / "openapi_3_petstore.modified.yaml"
 PATH_SPECS_INVALID_JSON = DIR / "invalid.json"
 PATH_SPECS_INVALID_YAML = DIR / "invalid.openapi.yaml"
 PATH_NOT_FOUND = DIR / "does/not/exist.yaml"
-OPERATION_FIELDS_2 = {"x-swagger-router-controller": "controllers"}
-OPERATION_FIELDS_2_NO_RESOLVE = {"x-swagger-router-controller": YAMLError}
+OPERATION_FIELDS_2 = {
+    "x-swagger-router-controller": "controllers",
+}
+OPERATION_FIELDS_2_NO_RESOLVE = {
+    "x-swagger-router-controller": YAMLError,
+}
 OPERATION_FIELDS_3 = {"x-openapi-router-controller": "controllers"}
-SECURITY_FIELDS_2 = {"x-apikeyInfoFunc": "controllers.validate_token"}
-SECURITY_FIELDS_3 = {"x-bearerInfoFunc": "controllers.validate_token"}
+SECURITY_FIELDS_2 = {
+    "x-apikeyInfoFunc": "controllers.validate_token",
+}
+SECURITY_FIELDS_3 = {
+    "x-bearerInfoFunc": "controllers.validate_token",
+}
 APPEND = {
     "info": {
         "version": "1.0.0",

--- a/tests/database/test_register_mongodb.py
+++ b/tests/database/test_register_mongodb.py
@@ -81,6 +81,29 @@ def test_register_mongodb_no_database():
     assert isinstance(res, MongoConfig)
 
 
+def test__create_mongo_client_with_mongo_uri(monkeypatch):
+    """When MONGO_URI environment variable IS defined, prefer it."""
+    # SRV style and options should be accepted without modification
+    mongo_uri = "mongodb://user:pass@db1.example.com:27017,db2.example.com:27017/admin?replicaSet=rs0&ssl=true"
+    monkeypatch.setenv("MONGO_URI", mongo_uri)
+    app = Flask(__name__)
+    res = _create_mongo_client(app)
+    assert isinstance(res, PyMongo)
+    assert app.config['MONGO_URI'] == mongo_uri
+
+
+def test__create_mongo_client_with_mongo_uri_and_db_override(monkeypatch):
+    """When MONGO_URI and MONGO_DBNAME are both defined, override db name."""
+    mongo_uri = "mongodb://localhost:27017/old_db?retryWrites=true&w=majority"
+    monkeypatch.setenv("MONGO_URI", mongo_uri)
+    monkeypatch.setenv("MONGO_DBNAME", "new_db")
+    app = Flask(__name__)
+    res = _create_mongo_client(app)
+    assert isinstance(res, PyMongo)
+    assert app.config['MONGO_URI'].startswith("mongodb://localhost:27017/new_db")
+    assert "retryWrites=true" in app.config['MONGO_URI']
+
+
 def test_register_mongodb_no_collections():
     """Register MongoDB database without any collections"""
     app = Flask(__name__)

--- a/tests/database/test_register_mongodb.py
+++ b/tests/database/test_register_mongodb.py
@@ -84,7 +84,10 @@ def test_register_mongodb_no_database():
 def test__create_mongo_client_with_mongo_uri(monkeypatch):
     """When MONGO_URI environment variable IS defined, prefer it."""
     # SRV style and options should be accepted without modification
-    mongo_uri = "mongodb://user:pass@db1.example.com:27017,db2.example.com:27017/admin?replicaSet=rs0&ssl=true"
+    mongo_uri = (
+        "mongodb://user:pass@db1.example.com:27017,"
+        "db2.example.com:27017/admin?replicaSet=rs0&ssl=true"
+    )
     monkeypatch.setenv("MONGO_URI", mongo_uri)
     app = Flask(__name__)
     res = _create_mongo_client(app)
@@ -100,7 +103,9 @@ def test__create_mongo_client_with_mongo_uri_and_db_override(monkeypatch):
     app = Flask(__name__)
     res = _create_mongo_client(app)
     assert isinstance(res, PyMongo)
-    assert app.config['MONGO_URI'].startswith("mongodb://localhost:27017/new_db")
+    assert app.config['MONGO_URI'].startswith(
+        "mongodb://localhost:27017/new_db"
+    )
     assert "retryWrites=true" in app.config['MONGO_URI']
 
 


### PR DESCRIPTION
…DBNAME overrides

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the [style guidelines](https://github.com/elixir-cloud-aai/elixir-cloud-aai/blob/dev/resources/contributing_guidelines.md#language-specific-guidelines) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation (or documentation does not need to be updated)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not reduced the existing code coverage

## Summary by Sourcery

Enhance MongoDB client registration to support using a full MONGO_URI environment variable with optional database name overrides via MONGO_DBNAME, falling back to legacy component-based configuration if not provided.

New Features:
- Allow providing a full MongoDB connection string via MONGO_URI environment variable
- Enable overriding the database name in the URI using the MONGO_DBNAME environment variable

Tests:
- Add tests to verify client creation with MONGO_URI and with MONGO_URI plus MONGO_DBNAME override